### PR TITLE
Flatten project data structure returned by API to match other data structures 

### DIFF
--- a/latitude_test.go
+++ b/latitude_test.go
@@ -105,10 +105,10 @@ func setupWithProject(t *testing.T) (*Client, string, func()) {
 		t.Fatal(err)
 	}
 
-	return c, p.Data.ID, func() {
-		_, err := c.Projects.Delete(p.Data.ID)
+	return c, p.ID, func() {
+		_, err := c.Projects.Delete(p.ID)
 		if err != nil {
-			panic(fmt.Errorf("while deleting %s: %s", p.Data.Attributes.Name, err))
+			panic(fmt.Errorf("while deleting %s: %s", p.Name, err))
 		}
 		stopRecord()
 	}
@@ -147,10 +147,10 @@ func projectTeardown(c *Client) {
 	}
 	for _, p := range ps {
 		fmt.Println(p.ID)
-		if strings.HasPrefix(p.Attributes.Name, testProjectPrefix) {
+		if strings.HasPrefix(p.Name, testProjectPrefix) {
 			_, err := c.Projects.Delete(p.ID)
 			if err != nil {
-				panic(fmt.Errorf("while deleting %s: %s", p.Attributes.Name, err))
+				panic(fmt.Errorf("while deleting %s: %s", p.Name, err))
 			}
 		}
 	}

--- a/projects.go
+++ b/projects.go
@@ -8,15 +8,14 @@ const projectBasePath = "/projects"
 
 // ProjectService interface defines available project methods
 type ProjectService interface {
-	List(listOpt *ListOptions) ([]ProjectData, *Response, error)
+	List(listOpt *ListOptions) ([]Project, *Response, error)
 	Get(string, *GetOptions) (*Project, *Response, error)
 	Create(*ProjectCreateRequest) (*Project, *Response, error)
 	Update(string, *ProjectUpdateRequest) (*Project, *Response, error)
 	Delete(string) (*Response, error)
 }
 
-// Project represents a Latitude project
-type Project struct {
+type ProjectRoot struct {
 	Data ProjectData `json:"data"`
 	Meta meta        `json:"meta"`
 }
@@ -24,10 +23,20 @@ type Project struct {
 type ProjectData struct {
 	ID         string            `json:"id"`
 	Type       string            `json:"type"`
-	Attributes ProjectAttributes `json:"attributes"`
+	Attributes ProjectGetAttributes `json:"attributes"`
 }
 
-type ProjectAttributes struct {
+type ProjectListResponse struct {
+	Data []ProjectData `json:"data"`
+	Meta     meta          `json:"meta"`
+}
+
+type ProjectGetResponse struct {
+	Data ProjectData `json:"data"`
+	Meta meta          `json:"meta"`
+}
+
+type ProjectGetAttributes struct {
 	Name          string `json:"name"`
 	Slug          string `json:"slug"`
 	Description   string `json:"description"`
@@ -36,18 +45,9 @@ type ProjectAttributes struct {
 	Environment   string `json:"environment"`
 }
 
-type ProjectListResponse struct {
-	Projects []ProjectData `json:"data"`
-	Meta     meta          `json:"meta"`
-}
-
 // ProjectCreateRequest type used to create a Latitude project
 type ProjectCreateRequest struct {
 	Data ProjectCreateData `json:"data"`
-}
-
-func (p ProjectCreateRequest) String() string {
-	return Stringify(p)
 }
 
 type ProjectCreateData struct {
@@ -72,30 +72,57 @@ type ProjectUpdateData struct {
 	Attributes ProjectCreateAttributes `json:"attributes"`
 }
 
-func (p ProjectUpdateRequest) String() string {
-	return Stringify(p)
-}
-
 // ProjectServiceOp implements ProjectService
 type ProjectServiceOp struct {
 	client requestDoer
 }
 
+type Project struct {
+	ID          string      `json:"id"`
+	Name    string      `json:"name"`
+	Slug       string      `json:"slug"`
+	Description        string      `json:"description"`
+	BillingType      string      `json:"billing_type"`
+	BillingMethod string      `json:"billing_method"`
+	Environment  string      `json:"environment"`
+}
+
+// Flatten latitude API data structures
+func NewFlatProject(pd ProjectData) Project {
+	return Project{
+		pd.ID,
+		pd.Attributes.Name,
+		pd.Attributes.Slug,
+		pd.Attributes.Description,
+		pd.Attributes.BillingType,
+		pd.Attributes.BillingMethod,
+		pd.Attributes.Environment,
+	}
+}
+
+func NewFlatProjectList(pd []ProjectData) []Project {
+	var res []Project
+	for _, project := range pd {
+		res = append(res, NewFlatProject(project))
+	}
+	return res
+}
+
 // List returns a list of projects
-func (s *ProjectServiceOp) List(opts *ListOptions) (projects []ProjectData, resp *Response, err error) {
+func (s *ProjectServiceOp) List(opts *ListOptions) (projects []Project, resp *Response, err error) {
 	apiPathQuery := opts.WithQuery(projectBasePath)
 
 	for {
-		subset := new(ProjectListResponse)
+		res := new(ProjectListResponse)
 
-		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, subset)
+		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, res)
 		if err != nil {
 			return nil, resp, err
 		}
 
-		projects = append(projects, subset.Projects...)
+		projects = append(projects, NewFlatProjectList(res.Data)...)
 
-		if apiPathQuery = nextPage(subset.Meta, opts); apiPathQuery != "" {
+		if apiPathQuery = nextPage(res.Meta, opts); apiPathQuery != "" {
 			continue
 		}
 
@@ -107,37 +134,41 @@ func (s *ProjectServiceOp) List(opts *ListOptions) (projects []ProjectData, resp
 func (s *ProjectServiceOp) Get(projectID string, opts *GetOptions) (*Project, *Response, error) {
 	endpointPath := path.Join(projectBasePath, projectID)
 	apiPathQuery := opts.WithQuery(endpointPath)
-	project := new(Project)
+	project := new(ProjectGetResponse)
 	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, project)
 	if err != nil {
 		return nil, resp, err
 	}
-	return project, resp, err
+
+	flatProject := NewFlatProject(project.Data)
+	return &flatProject, resp, err
 }
 
 // Create creates a new project
 func (s *ProjectServiceOp) Create(createRequest *ProjectCreateRequest) (*Project, *Response, error) {
-	project := new(Project)
+	project := new(ProjectGetResponse)
 
 	resp, err := s.client.DoRequest("POST", projectBasePath, createRequest, project)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return project, resp, err
+	flatProject := NewFlatProject(project.Data)
+	return &flatProject, resp, err
 }
 
 // Update updates a project
 func (s *ProjectServiceOp) Update(projectID string, updateRequest *ProjectUpdateRequest) (*Project, *Response, error) {
 	apiPath := path.Join(projectBasePath, projectID)
-	project := new(Project)
+	project := new(ProjectGetResponse)
 
 	resp, err := s.client.DoRequest("PATCH", apiPath, updateRequest, project)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return project, resp, err
+	flatProject := NewFlatProject(project.Data)
+	return &flatProject, resp, err
 }
 
 // Delete deletes a project

--- a/projects.go
+++ b/projects.go
@@ -21,19 +21,19 @@ type ProjectRoot struct {
 }
 
 type ProjectData struct {
-	ID         string            `json:"id"`
-	Type       string            `json:"type"`
+	ID         string               `json:"id"`
+	Type       string               `json:"type"`
 	Attributes ProjectGetAttributes `json:"attributes"`
 }
 
 type ProjectListResponse struct {
 	Data []ProjectData `json:"data"`
-	Meta     meta          `json:"meta"`
+	Meta meta          `json:"meta"`
 }
 
 type ProjectGetResponse struct {
 	Data ProjectData `json:"data"`
-	Meta meta          `json:"meta"`
+	Meta meta        `json:"meta"`
 }
 
 type ProjectGetAttributes struct {
@@ -78,13 +78,13 @@ type ProjectServiceOp struct {
 }
 
 type Project struct {
-	ID          string      `json:"id"`
-	Name    string      `json:"name"`
-	Slug       string      `json:"slug"`
-	Description        string      `json:"description"`
-	BillingType      string      `json:"billing_type"`
-	BillingMethod string      `json:"billing_method"`
-	Environment  string      `json:"environment"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Slug          string `json:"slug"`
+	Description   string `json:"description"`
+	BillingType   string `json:"billing_type"`
+	BillingMethod string `json:"billing_method"`
+	Environment   string `json:"environment"`
 }
 
 // Flatten latitude API data structures

--- a/projects_test.go
+++ b/projects_test.go
@@ -32,15 +32,15 @@ func TestAccProjectBasic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Data.Attributes.Name != rs {
-		t.Fatalf("Expected new project name to be %s, not %s", rs, p.Data.Attributes.Name)
+	if p.Name != rs {
+		t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
 	}
 
 	// Update newly created project
 	rs = testProjectPrefix + randString8()
 	pur := ProjectUpdateRequest{
 		Data: ProjectUpdateData{
-			ID:   p.Data.ID,
+			ID:   p.ID,
 			Type: testProjectType,
 			Attributes: ProjectCreateAttributes{
 				Name:        rs,
@@ -48,25 +48,25 @@ func TestAccProjectBasic(t *testing.T) {
 			},
 		},
 	}
-	p, _, err = c.Projects.Update(p.Data.ID, &pur)
+	p, _, err = c.Projects.Update(p.ID, &pur)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Data.Attributes.Name != rs {
-		t.Fatalf("Expected the name of the updated project to be %s, not %s", rs, p.Data.Attributes.Name)
+	if p.Name != rs {
+		t.Fatalf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
 	}
 
 	// Get newly updated project
-	gotProject, _, err := c.Projects.Get(p.Data.ID, nil)
+	gotProject, _, err := c.Projects.Get(p.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotProject.Data.Attributes.Name != rs {
-		t.Fatalf("Expected the name of the GOT project to be %s, not %s", rs, gotProject.Data.Attributes.Name)
+	if gotProject.Name != rs {
+		t.Fatalf("Expected the name of the GOT project to be %s, not %s", rs, gotProject.Name)
 	}
 
 	// Delete newly created project
-	_, err = c.Projects.Delete(p.Data.ID)
+	_, err = c.Projects.Delete(p.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,6 +86,6 @@ func TestAccListProjects(t *testing.T) {
 	}
 
 	for _, proj := range projs {
-		fmt.Println(proj.ID, proj.Attributes.Name)
+		fmt.Println(proj.ID, proj.Name)
 	}
 }

--- a/ssh_keys_test.go
+++ b/ssh_keys_test.go
@@ -37,10 +37,10 @@ func TestAccSSHKeyBasic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer deleteSSHKey(t, c, k.Data.ID, projectID)
+	defer deleteSSHKey(t, c, k.ID, projectID)
 
-	if k.Data.Attributes.Name != keyName {
-		t.Fatalf("Expected new SSH key name to be %s, not %s", keyName, k.Data.Attributes.Name)
+	if k.Name != keyName {
+		t.Fatalf("Expected new SSH key name to be %s, not %s", keyName, k.Name)
 	}
 
 	// Update newly created SSH key


### PR DESCRIPTION
RE: https://github.com/latitudesh/terraform-provider-latitudesh/issues/15

CHANGE: Flatten project data structure returned by API to match other data structures (servers, plans, regions)
ssh_keys - TODO: flatten data structure