### PR TITLE
List all operating systems available

### DIFF
--- a/latitude.go
+++ b/latitude.go
@@ -75,12 +75,13 @@ type Client struct {
 	ConsumerToken string
 	APIKey        string
 
-	Projects ProjectService
-	Servers  ServerService
-	UserData UserDataService
-	SSHKeys  SSHKeyService
-	Plans    PlanService
-	Regions  RegionService
+	Projects         ProjectService
+	Servers          ServerService
+	UserData         UserDataService
+	SSHKeys          SSHKeyService
+	Plans            PlanService
+	OperatingSystems OperatingSystemService
+	Regions          RegionService
 }
 
 type requestDoer interface {
@@ -310,6 +311,7 @@ func NewClientWithBaseURL(apiKey string, httpClient *http.Client, apiBaseURL str
 	c.SSHKeys = &SSHKeyServiceOp{client: c}
 	c.UserData = &UserDataServiceOp{client: c}
 	c.Plans = &PlanServiceOp{client: c}
+	c.OperatingSystems = &OperatingSystemServiceOp{client: c}
 	c.Regions = &RegionServiceOp{client: c}
 	c.debug = os.Getenv(debugEnvVar) != ""
 

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -2,7 +2,7 @@ package latitude
 
 const operatingSystemBasePath = "/plans/operating_systems"
 
-// OperatingSystemService interface defines available region methods
+// OperatingSystemService interface defines available Operating Systems methods
 type OperatingSystemService interface {
 	List(listOpt *ListOptions) ([]OperatingSystem, *Response, error)
 }

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -1,0 +1,98 @@
+package latitude
+
+const operatingSystemBasePath = "/plans/operating_systems"
+
+// RegionService interface defines available region methods
+type OperatinSystemService interface {
+	List(listOpt *ListOptions) ([]Region, *Response, error)
+}
+
+type OperatingSystemListResponse struct {
+	Data []OperatingSystemData `json:"data"`
+	Meta meta                  `json:"meta"`
+}
+
+type OperatingSystemData struct {
+	ID         string                    `json:"id"`
+	Type       string                    `json:"type"`
+	Attributes OperatingSystemAttributes `json:"attributes"`
+}
+
+type OperatingSystemAttributes struct {
+	Name     string                  `json:"name"`
+	Distro   string                  `json:"distro"`
+	Slug     string                  `json:"slug"`
+	Version  string                  `json:"version"`
+	User     string                  `json:"user"`
+	Features OperatingSystemFeatures `json:"features"`
+}
+
+type OperatingSystemFeatures struct {
+	Raid     bool `json:"raid"`
+	Rescue   bool `json:"rescue"`
+	SshKeys  bool `json:"ssh_keys"`
+	UserData bool `json:"user_data"`
+}
+
+type OperatingSystem struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	Distro   string `json:"distro"`
+	Slug     string `json:"slug"`
+	Version  string `json:"version"`
+	User     string `json:"user"`
+	Raid     bool   `json:"raid"`
+	Rescue   bool   `json:"rescue"`
+	SshKeys  bool   `json:"ssh_keys"`
+	UserData bool   `json:"user_data"`
+}
+
+type OperatingSystemServiceOp struct {
+	client requestDoer
+}
+
+func NewFlatOperatingSystem(osd OperatingSystemData) OperatingSystem {
+	return OperatingSystem{
+		osd.ID,
+		osd.Type,
+		osd.Attributes.Name,
+		osd.Attributes.Distro,
+		osd.Attributes.Slug,
+		osd.Attributes.Version,
+		osd.Attributes.User,
+		osd.Attributes.Features.Raid,
+		osd.Attributes.Features.Rescue,
+		osd.Attributes.Features.SshKeys,
+		osd.Attributes.Features.UserData,
+	}
+}
+
+func NewFlatOperatingSystemList(osd []OperatingSystemData) []OperatingSystem {
+	var res []OperatingSystem
+	for _, os := range osd {
+		res = append(res, NewFlatOperatingSystem(os))
+	}
+	return res
+}
+
+// List returns a list of regions
+func (os *OperatingSystemServiceOp) List(opts *ListOptions) (operatingSystems []OperatingSystem, resp *Response, err error) {
+	apiPathQuery := opts.WithQuery(operatingSystemBasePath)
+
+	for {
+		res := new(OperatingSystemListResponse)
+
+		resp, err = os.client.DoRequest("GET", apiPathQuery, nil, res)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		operatingSystems = append(operatingSystems, NewFlatOperatingSystemList(res.Data)...)
+
+		if apiPathQuery = nextPage(res.Meta, opts); apiPathQuery != "" {
+			continue
+		}
+		return
+	}
+}

--- a/operating_systems.go
+++ b/operating_systems.go
@@ -2,9 +2,9 @@ package latitude
 
 const operatingSystemBasePath = "/plans/operating_systems"
 
-// RegionService interface defines available region methods
-type OperatinSystemService interface {
-	List(listOpt *ListOptions) ([]Region, *Response, error)
+// OperatingSystemService interface defines available region methods
+type OperatingSystemService interface {
+	List(listOpt *ListOptions) ([]OperatingSystem, *Response, error)
 }
 
 type OperatingSystemListResponse struct {
@@ -76,7 +76,7 @@ func NewFlatOperatingSystemList(osd []OperatingSystemData) []OperatingSystem {
 	return res
 }
 
-// List returns a list of regions
+// List returns a list of Operating Systems
 func (os *OperatingSystemServiceOp) List(opts *ListOptions) (operatingSystems []OperatingSystem, resp *Response, err error) {
 	apiPathQuery := opts.WithQuery(operatingSystemBasePath)
 

--- a/operating_systems_test.go
+++ b/operating_systems_test.go
@@ -1,0 +1,45 @@
+package latitude
+
+import (
+	"testing"
+)
+
+func TestAccOperatingSystemBasic(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	c, stopRecord := setup(t)
+	defer stopRecord()
+
+	osl, _, err := c.OperatingSystems.List(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(osl) == 0 {
+		t.Fatalf("Operating System List should contain at least one plan")
+	}
+
+	OsTest := OperatingSystem{
+		ID:       "6",
+		Type:     "operating_system",
+		Name:     "CentOS 8",
+		Distro:   "centos",
+		Slug:     "centos_8_x64",
+		Version:  "8",
+		User:     "cloud-user",
+		Raid:     true,
+		Rescue:   true,
+		SshKeys:  true,
+		UserData: true,
+	}
+
+	// Check Operating System data
+	if OsTest.ID != osl[0].ID {
+		t.Fatalf("Expected the id of the Operating System to be %s, not %s", OsTest.ID, osl[0].ID)
+	}
+	if OsTest.Type != osl[0].Type {
+		t.Fatalf("Expected the type of the Operating System to be %s, not %s", OsTest.Type, osl[0].Type)
+	}
+	if OsTest.Name != osl[0].Name {
+		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Name, osl[0].Name)
+	}
+}

--- a/operating_systems_test.go
+++ b/operating_systems_test.go
@@ -18,7 +18,7 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 		t.Fatalf("Operating System List should contain at least one OS")
 	}
 
-	OsTest := OperatingSystem{
+	osTest := OperatingSystem{
 		ID:       "7",
 		Type:     "operating_system",
 		Name:     "CentOS 7.4",
@@ -33,37 +33,42 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 	}
 
 	// Check Operating System data
-	if OsTest.ID != osl[0].ID {
-		t.Fatalf("Expected the id of the Operating System to be %s, not %s", OsTest.ID, osl[0].ID)
+	for _, os := range osl {
+		if os.ID != osTest.ID {
+			continue
+		}
+
+		if osTest.Type != os.Type {
+			t.Fatalf("Expected the type of the Operating System to be %s, not %s", osTest.Type, os.Type)
+		}
+		if osTest.Name != os.Name {
+			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Name, os.Name)
+		}
+		if osTest.Distro != os.Distro {
+			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Distro, os.Distro)
+		}
+		if osTest.Slug != os.Slug {
+			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Slug, os.Slug)
+		}
+		if osTest.Version != os.Version {
+			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Version, os.Version)
+		}
+		if osTest.User != os.User {
+			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.User, os.User)
+		}
+		if osTest.Raid != os.Raid {
+			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Raid, os.Raid)
+		}
+		if osTest.Rescue != os.Rescue {
+			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Rescue, os.Rescue)
+		}
+		if osTest.SshKeys != os.SshKeys {
+			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.SshKeys, os.SshKeys)
+		}
+		if osTest.UserData != os.UserData {
+			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.UserData, os.UserData)
+		}
+		return
 	}
-	if OsTest.Type != osl[0].Type {
-		t.Fatalf("Expected the type of the Operating System to be %s, not %s", OsTest.Type, osl[0].Type)
-	}
-	if OsTest.Name != osl[0].Name {
-		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Name, osl[0].Name)
-	}
-	if OsTest.Distro != osl[0].Distro {
-		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Distro, osl[0].Distro)
-	}
-	if OsTest.Slug != osl[0].Slug {
-		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Slug, osl[0].Slug)
-	}
-	if OsTest.Version != osl[0].Version {
-		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Version, osl[0].Version)
-	}
-	if OsTest.User != osl[0].User {
-		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.User, osl[0].User)
-	}
-	if OsTest.Raid != osl[0].Raid {
-		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.Raid, osl[0].Raid)
-	}
-	if OsTest.Rescue != osl[0].Rescue {
-		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.Rescue, osl[0].Rescue)
-	}
-	if OsTest.SshKeys != osl[0].SshKeys {
-		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.SshKeys, osl[0].SshKeys)
-	}
-	if OsTest.UserData != osl[0].UserData {
-		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.UserData, osl[0].UserData)
-	}
+	t.Fatalf("Operating System with id %s not found", osTest.ID)
 }

--- a/operating_systems_test.go
+++ b/operating_systems_test.go
@@ -15,7 +15,7 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 	}
 
 	if len(osl) == 0 {
-		t.Fatalf("Operating System List should contain at least one plan")
+		t.Fatalf("Operating System List should contain at least one OS")
 	}
 
 	OsTest := OperatingSystem{

--- a/operating_systems_test.go
+++ b/operating_systems_test.go
@@ -19,13 +19,13 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 	}
 
 	OsTest := OperatingSystem{
-		ID:       "6",
+		ID:       "7",
 		Type:     "operating_system",
-		Name:     "CentOS 8",
+		Name:     "CentOS 7.4",
 		Distro:   "centos",
-		Slug:     "centos_8_x64",
-		Version:  "8",
-		User:     "cloud-user",
+		Slug:     "centos_7_4_x64",
+		Version:  "7.4",
+		User:     "centos",
 		Raid:     true,
 		Rescue:   true,
 		SshKeys:  true,
@@ -41,5 +41,29 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 	}
 	if OsTest.Name != osl[0].Name {
 		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Name, osl[0].Name)
+	}
+	if OsTest.Distro != osl[0].Distro {
+		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Distro, osl[0].Distro)
+	}
+	if OsTest.Slug != osl[0].Slug {
+		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Slug, osl[0].Slug)
+	}
+	if OsTest.Version != osl[0].Version {
+		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.Version, osl[0].Version)
+	}
+	if OsTest.User != osl[0].User {
+		t.Fatalf("Expected the name of the Operating System to be %s, not %s", OsTest.User, osl[0].User)
+	}
+	if OsTest.Raid != osl[0].Raid {
+		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.Raid, osl[0].Raid)
+	}
+	if OsTest.Rescue != osl[0].Rescue {
+		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.Rescue, osl[0].Rescue)
+	}
+	if OsTest.SshKeys != osl[0].SshKeys {
+		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.SshKeys, osl[0].SshKeys)
+	}
+	if OsTest.UserData != osl[0].UserData {
+		t.Fatalf("Expected the name of the Operating System to be %t, not %t", OsTest.UserData, osl[0].UserData)
 	}
 }


### PR DESCRIPTION
Adds Operating Systems module with `List` method for retrieving all available operating systems.

You can run tests using the golang Testing package:

```
LATITUDE_AUTH_TOKEN=<API TOKEN> LATITUDE_TEST_ACTUAL_API=true go test -timeout 30s -run "^TestAccOperatingSystemBasic$"
```
Or for manual testing use `go get` to download this branch:

```
go get github.com/latitudesh/latitudesh-go@list-operating-systems
```

### Usage:
```go
package main

import (
	"fmt"
	"os"

	latitude "github.com/latitudesh/latitudesh-go"
)

func main() {
	client := latitude.NewClientWithAuth("Latitude.sh", "<API TOKEN>", nil)

	list, res, err := client.OperatingSystems.List(nil)
	if err != nil {
		fmt.Fprintln(os.Stderr, err)
	}

	fmt.Printf("Status: %s\n", res.Status)
	fmt.Println(list)
}

```

Relevant documentation:
https://docs.latitude.sh/reference/get-plans-operating-system
