### PR TITLE
add IpxeUrl field to ServerCreateAttributes

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -87,6 +87,7 @@ type ServerCreateAttributes struct {
 	Hostname        string `json:"hostname"`
 	SSHKeys         []int  `json:"ssh_keys,omitempty"`
 	UserData        int    `json:"user_data,omitempty"`
+	IpxeUrl         string `json:"ipxe_url,omitempty"`
 }
 
 // ServerUpdateRequest type used to update a Latitude server

--- a/servers.go
+++ b/servers.go
@@ -201,11 +201,6 @@ func (s *ServerServiceOp) Get(serverID string, opts *GetOptions) (*Server, *Resp
 func (s *ServerServiceOp) Create(createRequest *ServerCreateRequest) (*Server, *Response, error) {
 	server := new(ServerGetResponse)
 
-	err := ValidateIpxe(createRequest)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	resp, err := s.client.DoRequest("POST", serverBasePath, createRequest, server)
 	if err != nil {
 		return nil, resp, err

--- a/servers.go
+++ b/servers.go
@@ -201,6 +201,11 @@ func (s *ServerServiceOp) Get(serverID string, opts *GetOptions) (*Server, *Resp
 func (s *ServerServiceOp) Create(createRequest *ServerCreateRequest) (*Server, *Response, error) {
 	server := new(ServerGetResponse)
 
+	err := ValidateIpxe(createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	resp, err := s.client.DoRequest("POST", serverBasePath, createRequest, server)
 	if err != nil {
 		return nil, resp, err

--- a/utils.go
+++ b/utils.go
@@ -130,7 +130,7 @@ func ValidateUUID(uuid string) error {
 	return nil
 }
 
-// Validates if iPXE Url is provided when ipxe deploying with iPXE.
+// Validates if iPXE Url is provided when deploying with iPXE.
 func ValidateIpxe(createServer *ServerCreateRequest) error {
 	if createServer.Data.Attributes.OperatingSystem != "ipxe" {
 		return nil

--- a/utils.go
+++ b/utils.go
@@ -129,14 +129,3 @@ func ValidateUUID(uuid string) error {
 	}
 	return nil
 }
-
-// Validates if iPXE Url is provided when deploying with iPXE.
-func ValidateIpxe(createServer *ServerCreateRequest) error {
-	if createServer.Data.Attributes.OperatingSystem != "ipxe" {
-		return nil
-	}
-	if createServer.Data.Attributes.IpxeUrl == "" {
-		return fmt.Errorf("iPXE script URL is needed when deploying with iPXE.")
-	}
-	return nil
-}

--- a/utils.go
+++ b/utils.go
@@ -129,3 +129,14 @@ func ValidateUUID(uuid string) error {
 	}
 	return nil
 }
+
+// Validates if iPXE Url is provided when ipxe deploying with iPXE.
+func ValidateIpxe(createServer *ServerCreateRequest) error {
+	if createServer.Data.Attributes.OperatingSystem != "ipxe" {
+		return nil
+	}
+	if createServer.Data.Attributes.IpxeUrl == "" {
+		return fmt.Errorf("An iPXE script URL is needed when deploying with iPXE.")
+	}
+	return nil
+}

--- a/utils.go
+++ b/utils.go
@@ -136,7 +136,7 @@ func ValidateIpxe(createServer *ServerCreateRequest) error {
 		return nil
 	}
 	if createServer.Data.Attributes.IpxeUrl == "" {
-		return fmt.Errorf("An iPXE script URL is needed when deploying with iPXE.")
+		return fmt.Errorf("iPXE script URL is needed when deploying with iPXE.")
 	}
 	return nil
 }


### PR DESCRIPTION
Adds IpxeUrl to ServerCreateAttributes so users can provide the required script in order to deploy with iPXE.

For manual testing use `go get` to download this branch:

```
go get github.com/latitudesh/latitudesh-go@PD-2789-Go-Client-Terraform-Allow-iPXE-to-be-used-on-deploy
```