### PR TITLE
feat: add raid field to ServerCreateAttributes

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -91,6 +91,7 @@ type ServerCreateAttributes struct {
 	Hostname        string `json:"hostname"`
 	SSHKeys         []int  `json:"ssh_keys,omitempty"`
 	UserData        int    `json:"user_data,omitempty"`
+	Raid            string `json:"raid,omitempty"`
 	IpxeUrl         string `json:"ipxe_url,omitempty"`
 }
 


### PR DESCRIPTION
#### What does this PR do?
Makes possible to specify a raid type when deploying a server.

#### Description of Task to be completed?
- add `Raid` field to `ServerCreateAttributes` struct

#### How should this be manually tested?
For manual testing use `go get` to download this branch:

```
go get github.com/latitudesh/latitudesh-go@Add-RAID-to-ServerCreateAttributes
```

#### Any background context you want to provide?

#### What are the relevant GitHub issues (if any)?

#### Screenshots (if appropriate):

#### Questions: