### PR TITLE
chore: remove deprecated archives.replacements

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,12 +15,16 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+        {{ .ProjectName }}_
+        {{- .Version }}_
+        {{- title .Os }}_
+        {{- if eq .Arch "darwin" }}Darwin
+        {{- else if eq .Arch "linux" }}Linux
+        {{- else if eq .Arch "windows" }}Windows
+        {{- else if eq .Arch "386" }}i386
+        {{- else if eq .Arch "amd64" }}x86_64
+        {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
**What does this PR do?**
It seems that in one of goreleaser last updates archive.replacements got completely removed, breaking the job.
https://goreleaser.com/deprecations/#archivesreplacements

**Description of Task to be completed?**
Update archives field in goreleaser.yaml in order to fix the pipeline.

**How should this be manually tested?**
You can test it locally  by installing goreleaser with `go install github.com/goreleaser/goreleaser@latest` and running `goreleaser check`

**Any background context you want to provide?**
Failed job: https://github.com/latitudesh/latitudesh-go/actions/runs/5455540503/jobs/9927128190