### PR TITLE
feat: add get method to vlan assignment

### DIFF
--- a/virtual_network_assignments.go
+++ b/virtual_network_assignments.go
@@ -1,11 +1,16 @@
 package latitude
 
-import "path"
+import (
+	"errors"
+	"net/http"
+	"path"
+)
 
 const vlanAssignmentBasePath = "/virtual_networks/assignments"
 
 type VlanAssignmentService interface {
 	List(listOpt *ListOptions) ([]VlanAssignment, *Response, error)
+	Get(VlanAssignmentID string) (*VlanAssignment, *Response, error)
 	Assign(assignRequest *VlanAssignRequest) (*VlanAssignment, *Response, error)
 	Delete(VlanAssignmentID string) (*Response, error)
 }
@@ -113,6 +118,26 @@ func (vn *VlanAssignmentServiceOp) List(opts *ListOptions) (vlanAssignments []Vl
 		}
 		return
 	}
+}
+
+func (s *VlanAssignmentServiceOp) Get(vlanAssignmentID string) (*VlanAssignment, *Response, error) {
+	vlans, resp, err := s.List(nil)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	for _, vlan := range vlans {
+		if vlan.ID == vlanAssignmentID {
+			return &vlan, resp, nil
+		}
+	}
+
+	resp.Status = "404 Not Found"
+	resp.StatusCode = http.StatusNotFound
+
+	notFoundErr := errors.New("ERROR\nStatus: 404\nSpecified Record Not Found")
+
+	return nil, resp, notFoundErr
 }
 
 func (s *VlanAssignmentServiceOp) Assign(assignRequest *VlanAssignRequest) (*VlanAssignment, *Response, error) {


### PR DESCRIPTION
#### What does this PR do?
In order to be able to peform assignments via Terraform, our client needs to be able to verify the existence of an assignment via ID (this verification is performed in the `terraform plan` step). This PR aims to create a method so we can perform said verification.
#### Description of Task to be completed?
- Add Get method to virtual_network_assignment.go
#### How should this be manually tested?
You can download this branch by using:
```
go get github.com/latitudesh/latitudesh-go@PD-3170-VLAN-support
```

### Usage:
```go
package main

import (
	"fmt"
	"os"

	latitude "github.com/latitudesh/latitudesh-go"
)

func main() {
	client := latitude.NewClientWithAuth("Latitude.sh", "<API-TOKEN>", nil)

	vlan, res, err := client.VlanAssignments.Get("<ASSIGNMENT-ID>")
	if err != nil {
		fmt.Fprintln(os.Stderr, err)
	}

	fmt.Printf("Status: %s\n", res.Status)
	fmt.Println(vlan)
}
```

#### Any background context you want to provide?
https://latitude.atlassian.net/browse/PD-3170

#### What are the relevant GitHub issues?
#### Screenshots (if appropriate)
#### Questions: