### PR TITLE
fix: SSHKeys type and ServerUpdateRequest

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -84,15 +84,15 @@ type ServerCreateData struct {
 }
 
 type ServerCreateAttributes struct {
-	Project         string `json:"project,omitempty"`
-	Plan            string `json:"plan,omitempty"`
-	Site            string `json:"site,omitempty"`
-	OperatingSystem string `json:"operating_system,omitempty"`
-	Hostname        string `json:"hostname"`
-	SSHKeys         []int  `json:"ssh_keys,omitempty"`
-	UserData        int    `json:"user_data,omitempty"`
-	Raid            string `json:"raid,omitempty"`
-	IpxeUrl         string `json:"ipxe_url,omitempty"`
+	Project         string   `json:"project,omitempty"`
+	Plan            string   `json:"plan,omitempty"`
+	Site            string   `json:"site,omitempty"`
+	OperatingSystem string   `json:"operating_system,omitempty"`
+	Hostname        string   `json:"hostname"`
+	SSHKeys         []string `json:"ssh_keys,omitempty"`
+	UserData        int      `json:"user_data,omitempty"`
+	Raid            string   `json:"raid,omitempty"`
+	IpxeUrl         string   `json:"ipxe_url,omitempty"`
 }
 
 // ServerUpdateRequest type used to update a Latitude server
@@ -103,7 +103,11 @@ type ServerUpdateRequest struct {
 type ServerUpdateData struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
-	Attributes ServerCreateAttributes `json:"attributes"`
+	Attributes ServerUpdateAttributes `json:"attributes"`
+}
+
+type ServerUpdateAttributes struct {
+	Hostname string `json:"hostname"`
 }
 
 // ServerServiceOp implements ServerService

--- a/servers_test.go
+++ b/servers_test.go
@@ -49,7 +49,7 @@ func TestAccServerBasic(t *testing.T) {
 		Data: ServerUpdateData{
 			ID:   s.ID,
 			Type: "servers",
-			Attributes: ServerCreateAttributes{
+			Attributes: ServerUpdateAttributes{
 				Hostname: rs,
 			},
 		},


### PR DESCRIPTION
#### What does this PR do?
Fix mismatches with docs
#### Description of Task to be completed?
- Update SSHKeys type from `[]int` to `[]string`
- Create ServerUpdateAttributes that matches the body that out api expects when updating a server 
#### How should this be manually tested?
By using golang test suit to run the tests:
You can run using this comand:
```
LATITUDE_AUTH_TOKEN=<API-TOKEN> LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=<RECORD-MODE> go test -run "^TestAccServerBasic$"
``` 
API-TOKEN: Your API Token
RECORD-MODE: `record` to record the requests or `play` to replay them
