### PR TITLE
Implement Server Reinstall, Fix Server Update Params, Refactor IDs From int To string

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -14,6 +14,7 @@ type ServerService interface {
 	Create(*ServerCreateRequest) (*Server, *Response, error)
 	Update(string, *ServerUpdateRequest) (*Server, *Response, error)
 	Delete(serverID string) (*Response, error)
+	Reinstall(serverID string, reinstallRequest *ServerReinstallRequest) (*Response, error)
 }
 
 type ServerRoot struct {
@@ -105,6 +106,23 @@ type ServerUpdateData struct {
 	Type       string                 `json:"type"`
 	Attributes ServerCreateAttributes `json:"attributes"`
 }
+type ServerReinstallRequest struct {
+	Data ServerReinstallData `json:"data"`
+}
+
+type ServerReinstallData struct {
+	Type       string                    `json:"type"`
+	Attributes ServerReinstallAttributes `json:"attributes"`
+}
+
+type ServerReinstallAttributes struct {
+	OperatingSystem string `json:"operating_system,omitempty"`
+	Hostname        string `json:"hostname"`
+	SSHKeys         []int  `json:"ssh_keys,omitempty"`
+	UserData        int    `json:"user_data,omitempty"`
+	Raid            string `json:"raid,omitempty"`
+	IpxeUrl         string `json:"ipxe_url,omitempty"`
+}
 
 // ServerServiceOp implements ServerService
 type ServerServiceOp struct {
@@ -128,7 +146,7 @@ type Server struct {
 }
 
 type ServerProject struct {
-	ID   int64  `json:"id"`
+	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
@@ -271,4 +289,11 @@ func (s *ServerServiceOp) Delete(serverID string) (*Response, error) {
 	apiPath := path.Join(serverBasePath, serverID)
 
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)
+}
+
+// Reinstall reinstalls an existing server
+func (s *ServerServiceOp) Reinstall(serverID string, reinstallRequest *ServerReinstallRequest) (*Response, error) {
+	apiPath := path.Join(serverBasePath, serverID, "reinstall")
+
+	return s.client.DoRequest("POST", apiPath, reinstallRequest, nil)
 }

--- a/servers.go
+++ b/servers.go
@@ -85,15 +85,15 @@ type ServerCreateData struct {
 }
 
 type ServerCreateAttributes struct {
-	Project         string `json:"project,omitempty"`
-	Plan            string `json:"plan,omitempty"`
-	Site            string `json:"site,omitempty"`
-	OperatingSystem string `json:"operating_system,omitempty"`
-	Hostname        string `json:"hostname"`
-	SSHKeys         []int  `json:"ssh_keys,omitempty"`
-	UserData        int    `json:"user_data,omitempty"`
-	Raid            string `json:"raid,omitempty"`
-	IpxeUrl         string `json:"ipxe_url,omitempty"`
+	Project         string   `json:"project,omitempty"`
+	Plan            string   `json:"plan,omitempty"`
+	Site            string   `json:"site,omitempty"`
+	OperatingSystem string   `json:"operating_system,omitempty"`
+	Hostname        string   `json:"hostname"`
+	SSHKeys         []string `json:"ssh_keys,omitempty"`
+	UserData        int      `json:"user_data,omitempty"`
+	Raid            string   `json:"raid,omitempty"`
+	IpxeUrl         string   `json:"ipxe_url,omitempty"`
 }
 
 // ServerUpdateRequest type used to update a Latitude server
@@ -104,7 +104,11 @@ type ServerUpdateRequest struct {
 type ServerUpdateData struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
-	Attributes ServerCreateAttributes `json:"attributes"`
+	Attributes ServerUpdateAttributes `json:"attributes"`
+}
+
+type ServerUpdateAttributes struct {
+	Hostname string `json:"hostname"`
 }
 type ServerReinstallRequest struct {
 	Data ServerReinstallData `json:"data"`
@@ -116,12 +120,12 @@ type ServerReinstallData struct {
 }
 
 type ServerReinstallAttributes struct {
-	OperatingSystem string `json:"operating_system,omitempty"`
-	Hostname        string `json:"hostname"`
-	SSHKeys         []int  `json:"ssh_keys,omitempty"`
-	UserData        int    `json:"user_data,omitempty"`
-	Raid            string `json:"raid,omitempty"`
-	IpxeUrl         string `json:"ipxe_url,omitempty"`
+	OperatingSystem string   `json:"operating_system,omitempty"`
+	Hostname        string   `json:"hostname"`
+	SSHKeys         []string `json:"ssh_keys,omitempty"`
+	UserData        int      `json:"user_data,omitempty"`
+	Raid            string   `json:"raid,omitempty"`
+	IpxeUrl         string   `json:"ipxe_url,omitempty"`
 }
 
 // ServerServiceOp implements ServerService

--- a/servers_test.go
+++ b/servers_test.go
@@ -49,7 +49,7 @@ func TestAccServerBasic(t *testing.T) {
 		Data: ServerUpdateData{
 			ID:   s.ID,
 			Type: "servers",
-			Attributes: ServerCreateAttributes{
+			Attributes: ServerUpdateAttributes{
 				Hostname: rs,
 			},
 		},


### PR DESCRIPTION
- Implement server reinstall API
- Fix the server update parameters to only accept hostname
- Refactor IDs to accept strings due to recent changes in the API