### PR TITLE
fix: change project id type

### DIFF
--- a/latitude.go
+++ b/latitude.go
@@ -24,7 +24,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "0.2.0"
+var currentVersion = "0.2.6"
 
 // meta contains pagination information
 type meta struct {

--- a/servers.go
+++ b/servers.go
@@ -150,8 +150,8 @@ type Server struct {
 }
 
 type ServerProject struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID   interface{} `json:"id"`
+	Name string      `json:"name"`
 }
 
 type ServerRegion struct {


### PR DESCRIPTION
#### What does this PR do?
We were having problems with ServerProject.ID, when deploying a server, our API expects it to be a string, but when we Read the server information, our API(v2) returns a number.
In order to solve this, this PR changes project ServerProjectID to `interface{`}, Internally golang is able to coerce this in the needed type (int64 for get, string for post)

#### Description of Task to be completed?
- Change ServerProject.ID type to `interface{}`

#### How should this be manually tested?
By using golang test suit to run the tests related to Servers:
```
LATITUDE_AUTH_TOKEN=<API-TOKEN> LATITUDE_TEST_ACTUAL_API=true go test -timeout 30s -run "^TestAccServerBasic$"
``` 

Or for manual testing use `go get` to download this branch:

```
go get github.com/latitudesh/latitudesh-go@fix/get-servers
```

### Usage:
```go
func main() {
	client := latitude.NewClientWithAuth("Latitude.sh", "<API-TOKEN>", nil)

	createAttr := latitudesh.ServerCreateAttributes{
		Project:         "qa",
		Plan:            "c3-small-x86",
		Site:            "SAO2",
		OperatingSystem: "ubuntu_22_04_x64_lts",
		Hostname:        "server-hostname",
	}

	createData := latitudesh.ServerCreateData{
		Type:       "server",
		Attributes: createAttr,
	}

	createReq := latitudesh.ServerCreateRequest{
		Data: createData,
	}

	ser, res, err := client.Servers.Create(&createReq)
	if err != nil {
		fmt.Println(err)
	}

	fmt.Printf("Status: %s\n", res.Status)
	fmt.Println(ser)
}
```
