### PR TITLE
Pd 3583 sdk add members endpoints

### DIFF
--- a/latitude.go
+++ b/latitude.go
@@ -91,6 +91,7 @@ type Client struct {
 	Regions          RegionService
 	Teams            TeamService
 	Bandwidth        BandwidthService
+	Members          MemberService
 }
 
 type requestDoer interface {
@@ -335,6 +336,7 @@ func NewClientWithBaseURL(apiKey string, httpClient *http.Client, apiBaseURL str
 	c.Regions = &RegionServiceOp{client: c}
 	c.VirtualNetworks = &VirtualNetworkServiceOp{client: c}
 	c.VlanAssignments = &VlanAssignmentServiceOp{client: c}
+	c.Members = &MemberServiceOp{client: c}
 	c.debug = os.Getenv(debugEnvVar) != ""
 
 	return c, nil

--- a/latitude.go
+++ b/latitude.go
@@ -25,7 +25,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "0.3.0"
+var currentVersion = "0.3.1"
 
 // meta contains pagination information
 type meta struct {

--- a/team_members.go
+++ b/team_members.go
@@ -38,10 +38,8 @@ type MemberListAttributes struct {
 }
 
 type Role struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type MemberResponse struct {
@@ -101,7 +99,7 @@ type Member struct {
 	RoleName   string `json:"role"`
 }
 
-// Flatten latitude API data structures
+// Flatten latitude API data structure
 func NewFlatMember(md MemberData) Member {
 	return Member{
 		md.ID,
@@ -116,13 +114,14 @@ func NewFlatMember(md MemberData) Member {
 }
 
 func NewFlatMemberList(md []MemberData) []Member {
-	var res []Member
+	var members []Member
 	for _, member := range md {
-		res = append(res, NewFlatMember(member))
+		members = append(members, NewFlatMember(member))
 	}
-	return res
+	return members
 }
 
+// List returns a list of team members
 func (s *MemberServiceOp) List(listOpts *ListOptions) (members []Member, resp *Response, err error) {
 	apiPathQuery := listOpts.WithQuery(memberBasePath)
 
@@ -163,6 +162,7 @@ func (s *MemberServiceOp) List(listOpts *ListOptions) (members []Member, resp *R
 	}
 }
 
+// Create creates a new team member
 func (s *MemberServiceOp) Create(request *MemberCreateRequest) (*Member, *Response, error) {
 	member := new(MemberResponse)
 
@@ -175,6 +175,7 @@ func (s *MemberServiceOp) Create(request *MemberCreateRequest) (*Member, *Respon
 	return &flatMember, resp, err
 }
 
+// Delete deletes a team member
 func (s *MemberServiceOp) Delete(MemberID string) (*Response, error) {
 	apiPath := path.Join(memberBasePath, MemberID)
 

--- a/team_members.go
+++ b/team_members.go
@@ -1,0 +1,126 @@
+package latitude
+
+const memberBasePath = "/team/members"
+
+// MemberService interface defines available member methods
+type MemberService interface {
+	List(listOpt *ListOptions) ([]User, *Response, error)
+	Create(request *MemberCreateRequest) (*User, *Response, error)
+	Delete(UserID string) (*Response, error)
+}
+
+// MemberServiceOp implements MemberService
+type MemberServiceOp struct {
+	client requestDoer
+}
+
+type MemberListResponse struct {
+	Data []MemberData `json:"data"`
+	Meta meta         `json:"meta"`
+}
+
+type MemberData struct {
+	ID         string           `json:"id"`
+	Type       string           `json:"type"`
+	Attributes MemberAttributes `json:"attributes"`
+}
+
+type MemberAttributes struct {
+	FirstName  string     `json:"first_name"`
+	LastName   string     `json:"last_name"`
+	Email      string     `json:"email"`
+	MfaEnabled bool       `json:"mfa_enabled"`
+	CreatedAt  string     `json:"created_at"`
+	UpdatedAt  string     `json:"updated_at"`
+	Role       RoleStruct `json:"role"`
+}
+
+type MemberCreateRequest struct {
+	Data MemberCreateData `json:"data"`
+	Meta meta             `json:"meta"`
+}
+
+type MemberCreateData struct {
+	Type       string                 `json:"type"`
+	Attributes MemberCreateAttributes `json:"attributes"`
+}
+
+type MemberCreateAttributes struct {
+	FirstName string   `json:"first_name"`
+	LastName  string   `json:"last_name"`
+	Email     string   `json:"email"`
+	Role      UserRole `json:"role"`
+}
+
+type UserRole string
+
+const (
+	Owner         UserRole = "owner"
+	Administrator UserRole = "administrator"
+	Collaborator  UserRole = "collaborator"
+	Billing       UserRole = "billing"
+)
+
+type User struct {
+	ID         string     `json:"id"`
+	FirstName  string     `json:"first_name"`
+	LastName   string     `json:"last_name"`
+	Email      string     `json:"email"`
+	MfaEnabled bool       `json:"mfa_enabled"`
+	CreatedAt  string     `json:"created_at"`
+	UpdatedAt  string     `json:"updated_at"`
+	Role       RoleStruct `json:"role"`
+}
+
+type RoleStruct struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Flatten latitude API data structures
+func NewFlatMember(md MemberData) User {
+	return User{
+		md.ID,
+		md.Attributes.FirstName,
+		md.Attributes.LastName,
+		md.Attributes.Email,
+		md.Attributes.MfaEnabled,
+		md.Attributes.CreatedAt,
+		md.Attributes.UpdatedAt,
+		md.Attributes.Role,
+	}
+}
+
+func NewFlatMemberList(md []MemberData) []User {
+	var res []User
+	for _, member := range md {
+		res = append(res, NewFlatMember(member))
+	}
+	return res
+}
+
+func (s *MemberServiceOp) List(listOpts *ListOptions) (members []User, resp *Response, err error) {
+	apiPathQuery := listOpts.WithQuery(memberBasePath)
+
+	for {
+		res := new(MemberListResponse)
+
+		resp, err = s.client.DoRequest("GET", apiPathQuery, nil, res)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		members = append(members, NewFlatMemberList(res.Data)...)
+
+		if apiPathQuery = nextPage(res.Meta, listOpts); apiPathQuery != "" {
+			continue
+		}
+
+		return
+	}
+}
+
+func (s *MemberServiceOp) Create(request *MemberCreateRequest) (*User, *Response, error)
+func (s *MemberServiceOp) Delete(UserID string) (*Response, error)

--- a/team_members_test.go
+++ b/team_members_test.go
@@ -1,0 +1,52 @@
+package latitude
+
+import (
+	"testing"
+)
+
+const ()
+
+func deleteMember(t *testing.T, c *Client, id string) {
+	if _, err := c.Members.Delete(id); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccMembersBasic(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+
+	c, stopRecord := setup(t)
+	defer stopRecord()
+	defer projectTeardown(c)
+
+	// List Members
+	members, _, err := c.Members.List(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(members) < 1 {
+		t.Fatal("Team must have at least a owner")
+	}
+
+	//Create Member
+	request := MemberCreateRequest{
+		Data: MemberCreateData{
+			Type: "memberships",
+			Attributes: MemberCreateAttributes{
+				FirstName: "go-sdk",
+				LastName:  "test",
+				Email:     "go_sdk_test@latitude.sh",
+				Role:      Collaborator,
+			},
+		},
+	}
+
+	m, _, err := c.Members.Create(&request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Delete Member
+	deleteMember(t, c, m.ID)
+}


### PR DESCRIPTION
#### What does this PR do?
Implements `Members` endpoint

#### Description of Task to be completed?
- Implement List, Create and Delete Methods
- Add tests

#### How should this be manually tested?
By using golang test suit you can run all our tests
```
LATITUDE_AUTH_TOKEN=<API-TOKEN> LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=<RECORD-MODE> go test -run "^TestAccMembersBasic$"
``` 
The `<RECORD-MODE>` variable can be `record` or `play`

Or for manual testing use `go get` to download this branch in a local project:

```
go get github.com/latitudesh/latitudesh-go@PD-3583-SDK-Add-Members-endpoints
```
#### Any background context you want to provide?
- https://docs.latitude.sh/reference/get-team-members

