### PR TITLE
chore: refactor servers and virtual_networks tests

### DIFF
--- a/latitude_test.go
+++ b/latitude_test.go
@@ -31,9 +31,9 @@ const (
 	recorderDefaultMode  = recorder.ModePassthrough
 
 	// defaults should be available to most users
-	testSiteDefault            = "ASH"
+	testSiteDefault            = "SAO"
 	testPlanDefault            = "c2-small-x86"
-	testRegionDefault          = "ASH"
+	testRegionDefault          = "SAO"
 	testSSHKeyDefault          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDQZtz6DPH4Y04vYLdOch5xOzDY7cdGWpYjBFx5H7ZzieVoRwartZAVTGX4qFT9aoyCuuE6qXYcTj6G1CdO5fb8iOtU6K3FdzVyw/WQ/c4sCehEL+wbYrOnXJSYMhLsUAFhZ69tTdmQSgctbv44yP32Z4xiE4zc/Bk465F3u4Zi1Jj883fyAgzahTWXOxpmvYAEuS6Qv6w4yJc6giiGFVYmu+N6h9j348UgbpToYiCSnSM4iNa9fs7sBGufOa9FuXtggPfXtpyk9f05AhkKEjPlCXcDNAq0GsvN2QEx3tYw6i5ze0qehv6EBAtwx3PLrj636O6IgSh0DgrZBih9NBov"
 	testUserDataContentDefault = "bGF0aXR1ZGVzaCB1c2VyIGRhdGEgZXhhbXBsZQ=="
 	testOperatingSystemDefault = "ubuntu_22_04_x64_lts"

--- a/latitude_test.go
+++ b/latitude_test.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
@@ -87,7 +86,6 @@ func randString8() string {
 	}
 
 	n := 8
-	rand.Seed(time.Now().UnixNano())
 	letterRunes := []rune("acdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)
 	for i := range b {

--- a/latitude_test.go
+++ b/latitude_test.go
@@ -211,3 +211,9 @@ func testRecorder(t *testing.T, name string, mode recorder.Mode) (*recorder.Reco
 		}
 	}
 }
+
+func assertEqual(t *testing.T, actual, expected interface{}, fieldName string) {
+	if actual != expected {
+		t.Fatalf("Expected %s to be %v, but got %v", fieldName, expected, actual)
+	}
+}

--- a/latitude_test.go
+++ b/latitude_test.go
@@ -156,7 +156,6 @@ func projectTeardown(c *Client) {
 		panic(fmt.Errorf("while teardown: %s", err))
 	}
 	for _, p := range ps {
-		fmt.Println(p.ID)
 		if strings.HasPrefix(p.Name, testProjectPrefix) {
 			_, err := c.Projects.Delete(p.ID)
 			if err != nil {

--- a/operating_systems_test.go
+++ b/operating_systems_test.go
@@ -39,36 +39,17 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 				continue
 			}
 
-			if osTest.Type != os.Type {
-				t.Fatalf("Expected the type of the Operating System to be %s, not %s", osTest.Type, os.Type)
-			}
-			if osTest.Name != os.Name {
-				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Name, os.Name)
-			}
-			if osTest.Distro != os.Distro {
-				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Distro, os.Distro)
-			}
-			if osTest.Slug != os.Slug {
-				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Slug, os.Slug)
-			}
-			if osTest.Version != os.Version {
-				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Version, os.Version)
-			}
-			if osTest.User != os.User {
-				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.User, os.User)
-			}
-			if osTest.Raid != os.Raid {
-				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Raid, os.Raid)
-			}
-			if osTest.Rescue != os.Rescue {
-				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Rescue, os.Rescue)
-			}
-			if osTest.SshKeys != os.SshKeys {
-				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.SshKeys, os.SshKeys)
-			}
-			if osTest.UserData != os.UserData {
-				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.UserData, os.UserData)
-			}
+			assertEqual(t, os.Type, osTest.Type, "Operating System Type")
+			assertEqual(t, os.Name, osTest.Name, "Operating System Name")
+			assertEqual(t, os.Distro, osTest.Distro, "Operating System Distro")
+			assertEqual(t, os.Slug, osTest.Slug, "Operating System Slug")
+			assertEqual(t, os.Version, osTest.Version, "Operating System Version")
+			assertEqual(t, os.User, osTest.User, "Operating System User")
+			assertEqual(t, os.Raid, osTest.Raid, "Operating System Raid")
+			assertEqual(t, os.Rescue, osTest.Rescue, "Operating System Rescue")
+			assertEqual(t, os.SshKeys, osTest.SshKeys, "Operating System SshKeys")
+			assertEqual(t, os.UserData, osTest.UserData, "Operating System UserData")
+
 			return
 		}
 		t.Fatalf("Operating System with id %s not found", osTest.ID)

--- a/operating_systems_test.go
+++ b/operating_systems_test.go
@@ -9,66 +9,68 @@ func TestAccOperatingSystemBasic(t *testing.T) {
 	c, stopRecord := setup(t)
 	defer stopRecord()
 
-	osl, _, err := c.OperatingSystems.List(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(osl) == 0 {
-		t.Fatalf("Operating System List should contain at least one OS")
-	}
-
-	osTest := OperatingSystem{
-		ID:       "os_KgXQvNe3azpbP",
-		Type:     "operating_system",
-		Name:     "CentOS 7.4",
-		Distro:   "centos",
-		Slug:     "centos_7_4_x64",
-		Version:  "7.4",
-		User:     "centos",
-		Raid:     true,
-		Rescue:   true,
-		SshKeys:  true,
-		UserData: true,
-	}
-
-	// Check Operating System data
-	for _, os := range osl {
-		if os.ID != osTest.ID {
-			continue
+	t.Run("List Operating Systems", func(t *testing.T) {
+		osl, _, err := c.OperatingSystems.List(nil)
+		if err != nil {
+			t.Fatal(err)
 		}
 
-		if osTest.Type != os.Type {
-			t.Fatalf("Expected the type of the Operating System to be %s, not %s", osTest.Type, os.Type)
+		if len(osl) == 0 {
+			t.Fatalf("Operating System List should contain at least one OS")
 		}
-		if osTest.Name != os.Name {
-			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Name, os.Name)
+
+		osTest := OperatingSystem{
+			ID:       "os_KgXQvNe3azpbP",
+			Type:     "operating_system",
+			Name:     "CentOS 7.4",
+			Distro:   "centos",
+			Slug:     "centos_7_4_x64",
+			Version:  "7.4",
+			User:     "centos",
+			Raid:     true,
+			Rescue:   true,
+			SshKeys:  true,
+			UserData: true,
 		}
-		if osTest.Distro != os.Distro {
-			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Distro, os.Distro)
+
+		// Check Operating System data
+		for _, os := range osl {
+			if os.ID != osTest.ID {
+				continue
+			}
+
+			if osTest.Type != os.Type {
+				t.Fatalf("Expected the type of the Operating System to be %s, not %s", osTest.Type, os.Type)
+			}
+			if osTest.Name != os.Name {
+				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Name, os.Name)
+			}
+			if osTest.Distro != os.Distro {
+				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Distro, os.Distro)
+			}
+			if osTest.Slug != os.Slug {
+				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Slug, os.Slug)
+			}
+			if osTest.Version != os.Version {
+				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Version, os.Version)
+			}
+			if osTest.User != os.User {
+				t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.User, os.User)
+			}
+			if osTest.Raid != os.Raid {
+				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Raid, os.Raid)
+			}
+			if osTest.Rescue != os.Rescue {
+				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Rescue, os.Rescue)
+			}
+			if osTest.SshKeys != os.SshKeys {
+				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.SshKeys, os.SshKeys)
+			}
+			if osTest.UserData != os.UserData {
+				t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.UserData, os.UserData)
+			}
+			return
 		}
-		if osTest.Slug != os.Slug {
-			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Slug, os.Slug)
-		}
-		if osTest.Version != os.Version {
-			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.Version, os.Version)
-		}
-		if osTest.User != os.User {
-			t.Fatalf("Expected the name of the Operating System to be %s, not %s", osTest.User, os.User)
-		}
-		if osTest.Raid != os.Raid {
-			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Raid, os.Raid)
-		}
-		if osTest.Rescue != os.Rescue {
-			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.Rescue, os.Rescue)
-		}
-		if osTest.SshKeys != os.SshKeys {
-			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.SshKeys, os.SshKeys)
-		}
-		if osTest.UserData != os.UserData {
-			t.Fatalf("Expected the name of the Operating System to be %t, not %t", osTest.UserData, os.UserData)
-		}
-		return
-	}
-	t.Fatalf("Operating System with id %s not found", osTest.ID)
+		t.Fatalf("Operating System with id %s not found", osTest.ID)
+	})
 }

--- a/plans_test.go
+++ b/plans_test.go
@@ -25,76 +25,39 @@ func TestAccPlanBasic(t *testing.T) {
 	}
 
 	// Check plan data
-	if gotPlan.ID != pl[0].ID {
-		t.Fatalf("Expected the id of the GOT plan to be %s, not %s", pl[0].ID, gotPlan.ID)
-	}
-	if gotPlan.Line != pl[0].Line {
-		t.Fatalf("Expected the line of the GOT plan to be %s, not %s", pl[0].Line, gotPlan.Line)
-	}
-	if gotPlan.Name != pl[0].Name {
-		t.Fatalf("Expected the name of the GOT plan to be %s, not %s", pl[0].Name, gotPlan.Name)
-	}
-	if gotPlan.Type != pl[0].Type {
-		t.Fatalf("Expected the type of the GOT plan to be %s, not %s", pl[0].Type, gotPlan.Type)
-	}
+	assertEqual(t, gotPlan.ID, pl[0].ID, "Plan ID")
+	assertEqual(t, gotPlan.Name, pl[0].Name, "Plan Name")
+	assertEqual(t, gotPlan.Type, pl[0].Type, "Plan ID")
 
 	// Check plan features
-	if len(gotPlan.Features) != len(pl[0].Features) {
-		t.Fatalf("Expected the length of the GOT plan features to be %d, not %d", len(pl[0].Features), len(gotPlan.Features))
-	}
+	assertEqual(t, len(gotPlan.Features), len(pl[0].Features), "Plan features lenght")
 
 	// Check plan specs Memorys
-	if gotPlan.Specs.Memory.Total != pl[0].Specs.Memory.Total {
-		t.Fatalf("Expected the memory total of the GOT plan to be %v, not %v", pl[0].Specs.Memory.Total, gotPlan.Specs.Memory.Total)
-	}
+	assertEqual(t, gotPlan.Specs.Memory.Total, pl[0].Specs.Memory.Total, "Plan total memory")
 
 	// Check plan specs (CPUs)
-	for i, cpu := range gotPlan.Specs.CPUs {
-		if cpu.Type != pl[0].Specs.CPUs[i].Type {
-			t.Fatalf("Expected the CPU type of the GOT plan to be %s, not %s", cpu.Type, pl[0].Specs.CPUs[i].Type)
-		}
-		if cpu.Clock != pl[0].Specs.CPUs[i].Clock {
-			t.Fatalf("Expected the CPU clock of the GOT plan to be %f, not %f", cpu.Clock, pl[0].Specs.CPUs[i].Clock)
-		}
-		if cpu.Cores != pl[0].Specs.CPUs[i].Cores {
-			t.Fatalf("Expected the CPU cores of the GOT plan to be %d, not %d", cpu.Cores, pl[0].Specs.CPUs[i].Cores)
-		}
-		if cpu.Count != pl[0].Specs.CPUs[i].Count {
-			t.Fatalf("Expected the CPU count of the GOT plan to be %d, not %d", cpu.Count, pl[0].Specs.CPUs[i].Count)
-		}
-	}
+	cpu := gotPlan.Specs.CPU
+	assertEqual(t, cpu.Type, pl[0].Specs.CPU.Type, "Plan CPU type")
+	assertEqual(t, cpu.Clock, pl[0].Specs.CPU.Clock, "Plan CPU clock")
+	assertEqual(t, cpu.Cores, pl[0].Specs.CPU.Cores, "Plan CPU cores")
+	assertEqual(t, cpu.Count, pl[0].Specs.CPU.Count, "Plan CPU count")
 
 	// Check plan specs (drives)
 	for i, drive := range gotPlan.Specs.Drives {
-		if drive.Type != pl[0].Specs.Drives[i].Type {
-			t.Fatalf("Expected the drive type of the GOT plan to be %s, not %s", drive.Type, pl[0].Specs.Drives[i].Type)
-		}
-		if drive.Count != pl[0].Specs.Drives[i].Count {
-			t.Fatalf("Expected the drive count of the GOT plan to be %d, not %d", drive.Count, pl[0].Specs.Drives[i].Count)
-		}
-		if drive.Size != pl[0].Specs.Drives[i].Size {
-			t.Fatalf("Expected the drive size of the GOT plan to be %s, not %s", drive.Size, pl[0].Specs.Drives[i].Size)
-		}
+		assertEqual(t, drive.Type, pl[0].Specs.Drives[i].Type, "Plan Drive type")
+		assertEqual(t, drive.Count, pl[0].Specs.Drives[i].Count, "Plan Drive count")
+		assertEqual(t, drive.Size, pl[0].Specs.Drives[i].Size, "Plan Drive size")
 	}
 
 	// Check plan specs (NICs)
 	for i, nic := range gotPlan.Specs.NICs {
-		if nic.Count != pl[0].Specs.NICs[i].Count {
-			t.Fatalf("Expected the NIC count of the GOT plan to be %d, not %d", nic.Count, pl[0].Specs.NICs[i].Count)
-		}
-		if nic.Type != pl[0].Specs.NICs[i].Type {
-			t.Fatalf("Expected the NIC type of the GOT plan to be %s, not %s", nic.Type, pl[0].Specs.NICs[i].Type)
-		}
+		assertEqual(t, nic.Count, pl[0].Specs.NICs[i].Count, "Plan NIC count")
+		assertEqual(t, nic.Type, pl[0].Specs.NICs[i].Type, "Plan NIC type")
 	}
 
 	// Check plan availability
-	for i, availability := range gotPlan.Availibility {
-		if availability.Region.ID != pl[0].Availibility[i].Region.ID {
-			t.Fatalf("Expected the availability region id of the GOT plan to be %d, not %d", availability.Region.ID, pl[0].Availibility[i].Region.ID)
-		}
-		if availability.Region.Name != pl[0].Availibility[i].Region.Name {
-			t.Fatalf("Expected the availability region name of the GOT plan to be %s, not %s", availability.Region.Name, pl[0].Availibility[i].Region.Name)
-		}
+	for i, stock := range gotPlan.InStock {
+		assertEqual(t, stock, pl[0].InStock[i], "Plan available stock")
 	}
 }
 

--- a/projects_test.go
+++ b/projects_test.go
@@ -41,9 +41,7 @@ func TestAccProjectBasic(t *testing.T) {
 
 		projectID = p.ID
 
-		if p.Name != rs {
-			t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
-		}
+        assertEqual(t, p.Name, rs, "Project Name")
 	})
 
 	defer deleteProject(t, c, projectID)
@@ -68,10 +66,7 @@ func TestAccProjectBasic(t *testing.T) {
 		}
 
 		projectName = p.Name
-
-		if p.Name != rs {
-			t.Fatalf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
-		}
+        assertEqual(t, projectName, rs, "Project Name")
 	})
 
 	t.Run("Get Project", func(t *testing.T) {
@@ -80,9 +75,7 @@ func TestAccProjectBasic(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if gotProject.Name != projectName {
-			t.Fatalf("Expected the name of the GOT project to be %s, not %s", projectName, gotProject.Name)
-		}
+        assertEqual(t, gotProject.Name, projectName, "Project Name")
 	})
 
 	t.Run("List Project", func(t *testing.T) {

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,7 +1,6 @@
 package latitude
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -10,74 +9,90 @@ const (
 	testProjectEnvironment = "Development"
 )
 
+func deleteProject(t *testing.T, c *Client, id string) {
+	if _, err := c.Projects.Delete(id); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAccProjectBasic(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
-
 	c, stopRecord := setup(t)
 	defer stopRecord()
 	defer projectTeardown(c)
 
-	// List Projects
-	projs, _, err := c.Projects.List(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, proj := range projs {
-		fmt.Println(proj.ID, proj.Name)
-	}
-
-	// Create a new project
-	rs := testProjectPrefix + randString8()
-	pcr := ProjectCreateRequest{
-		Data: ProjectCreateData{
-			Type: testProjectType,
-			Attributes: ProjectCreateAttributes{
-				Name:        rs,
-				Environment: testProjectEnvironment,
+	var projectID string
+	t.Run("Create Project", func(t *testing.T) {
+		// Create a new project
+		rs := testProjectPrefix + randString8()
+		pcr := ProjectCreateRequest{
+			Data: ProjectCreateData{
+				Type: testProjectType,
+				Attributes: ProjectCreateAttributes{
+					Name:        rs,
+					Environment: testProjectEnvironment,
+				},
 			},
-		},
-	}
-	p, _, err := c.Projects.Create(&pcr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if p.Name != rs {
-		t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
-	}
+		}
+		p, _, err := c.Projects.Create(&pcr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// Update newly created project
-	rs = testProjectPrefix + randString8()
-	pur := ProjectUpdateRequest{
-		Data: ProjectUpdateData{
-			ID:   p.ID,
-			Type: testProjectType,
-			Attributes: ProjectCreateAttributes{
-				Name:        rs,
-				Environment: testProjectEnvironment,
+		projectID = p.ID
+
+		if p.Name != rs {
+			t.Fatalf("Expected new project name to be %s, not %s", rs, p.Name)
+		}
+	})
+
+	defer deleteProject(t, c, projectID)
+
+	var projectName string
+	t.Run("Update Project", func(t *testing.T) {
+		rs := testProjectPrefix + randString8()
+		pur := ProjectUpdateRequest{
+			Data: ProjectUpdateData{
+				ID:   projectID,
+				Type: testProjectType,
+				Attributes: ProjectCreateAttributes{
+					Name:        rs,
+					Environment: testProjectEnvironment,
+				},
 			},
-		},
-	}
-	p, _, err = c.Projects.Update(p.ID, &pur)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if p.Name != rs {
-		t.Fatalf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
-	}
+		}
 
-	// Get newly updated project
-	gotProject, _, err := c.Projects.Get(p.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotProject.Name != rs {
-		t.Fatalf("Expected the name of the GOT project to be %s, not %s", rs, gotProject.Name)
-	}
+		p, _, err := c.Projects.Update(projectID, &pur)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// Delete newly created project
-	_, err = c.Projects.Delete(p.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
+		projectName = p.Name
+
+		if p.Name != rs {
+			t.Fatalf("Expected the name of the updated project to be %s, not %s", rs, p.Name)
+		}
+	})
+
+	t.Run("Get Project", func(t *testing.T) {
+		gotProject, _, err := c.Projects.Get(projectID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if gotProject.Name != projectName {
+			t.Fatalf("Expected the name of the GOT project to be %s, not %s", projectName, gotProject.Name)
+		}
+	})
+
+	t.Run("List Project", func(t *testing.T) {
+		projs, _, err := c.Projects.List(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(projs) == 0 {
+			t.Fatalf("Project List should contain at least one project")
+		}
+	})
 }

--- a/regions_test.go
+++ b/regions_test.go
@@ -25,24 +25,12 @@ func TestAccRegionBasic(t *testing.T) {
 	}
 
 	// Check region data
-	if gotRegion.ID != rl[0].ID {
-		t.Fatalf("Expected the id of the GOT region to be %s, not %s", rl[0].ID, gotRegion.ID)
-	}
-	if gotRegion.Type != rl[0].Type {
-		t.Fatalf("Expected the type of the GOT region to be %s, not %s", rl[0].Type, gotRegion.Type)
-	}
-	if gotRegion.Slug != rl[0].Slug {
-		t.Fatalf("Expected the slug of the GOT region to be %s, not %s", rl[0].Slug, gotRegion.Slug)
-	}
-	if gotRegion.Facility != rl[0].Facility {
-		t.Fatalf("Expected the line of the GOT region to be %s, not %s", rl[0].Facility, gotRegion.Facility)
-	}
-	if gotRegion.CountryName != rl[0].CountryName {
-		t.Fatalf("Expected the country name of the GOT region to be %s, not %s", rl[0].CountryName, gotRegion.CountryName)
-	}
-	if gotRegion.CountrySlug != rl[0].CountrySlug {
-		t.Fatalf("Expected the country slug of the GOT region to be %s, not %s", rl[0].CountrySlug, gotRegion.CountrySlug)
-	}
+	assertEqual(t, gotRegion.ID, rl[0].ID, "Regions ID")
+	assertEqual(t, gotRegion.Type, rl[0].Type, "Regions Type")
+	assertEqual(t, gotRegion.Slug, rl[0].Slug, "Regions Slug")
+	assertEqual(t, gotRegion.Facility, rl[0].Facility, "Regions Facility")
+	assertEqual(t, gotRegion.CountryName, rl[0].CountryName, "Regions Country Name")
+	assertEqual(t, gotRegion.CountrySlug, rl[0].CountrySlug, "Regions Country Slug")
 }
 
 func TestAccRegionFilter(t *testing.T) {
@@ -54,8 +42,5 @@ func TestAccRegionFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if len(rl) != 1 {
-		t.Fatalf("Filtered region list should contain one plan: returned %d", len(rl))
-	}
+	assertEqual(t, len(rl), 1, "Region List")
 }

--- a/servers_test.go
+++ b/servers_test.go
@@ -63,9 +63,7 @@ func TestAccServerBasic(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if s.Hostname != rs {
-			t.Fatalf("Expected the hostname of the updated server to be %s, not %s", rs, s.Hostname)
-		}
+        assertEqual(t, s.Hostname, rs, "Server hostname")
 	})
 
 	t.Run("Servers List test", func(t *testing.T) {
@@ -73,9 +71,6 @@ func TestAccServerBasic(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		if len(dl) != 1 {
-			t.Fatalf("Server List should contain exactly one server, was: %v", dl)
-		}
+        assertEqual(t, len(dl), 1, "Server List length")
 	})
 }

--- a/ssh_keys_test.go
+++ b/ssh_keys_test.go
@@ -21,79 +21,88 @@ func TestAccSSHKeyBasic(t *testing.T) {
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 
-	// Create a new SSH Key
-	keyName := randString8()
-	skcr := SSHKeyCreateRequest{
-		Data: SSHKeyCreateData{
-			Type: testSSHKeyType,
-			Attributes: SSHKeyCreateAttributes{
-				Name:      keyName,
-				PublicKey: testSSHKey(),
+	var keyID string
+
+	t.Run("Create SSH Key", func(t *testing.T) {
+		keyName := randString8()
+		skcr := SSHKeyCreateRequest{
+			Data: SSHKeyCreateData{
+				Type: testSSHKeyType,
+				Attributes: SSHKeyCreateAttributes{
+					Name:      keyName,
+					PublicKey: testSSHKey(),
+				},
 			},
-		},
-	}
+		}
 
-	k, _, err := c.SSHKeys.Create(projectID, &skcr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer deleteSSHKey(t, c, k.ID, projectID)
+		k, _, err := c.SSHKeys.Create(projectID, &skcr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if k.Name != keyName {
-		t.Fatalf("Expected new SSH key name to be %s, not %s", keyName, k.Name)
-	}
+		if k.Name != keyName {
+			t.Fatalf("Expected new SSH key name to be %s, not %s", keyName, k.Name)
+		}
 
-	kList, _, err := c.SSHKeys.List(projectID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+		keyID = k.ID
+	})
 
-	if len(kList) == 0 {
-		t.Fatalf("Plan List should contain at least one plan")
-	}
+	defer deleteSSHKey(t, c, keyID, projectID)
 
-	// Get first listed SSHkey
-	gotKey, _, err := c.SSHKeys.Get(kList[0].ID, projectID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("Get and List SSHKeys", func(t *testing.T) {
+		kList, _, err := c.SSHKeys.List(projectID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// Check SSHKey data
-	if gotKey.ID != kList[0].ID {
-		t.Fatalf("Expected the id of the GOT plan to be %s, not %s", kList[0].ID, gotKey.ID)
-	}
-	if gotKey.Name != kList[0].Name {
-		t.Fatalf("Expected the Name of the GOT plan to be %s, not %s", kList[0].Name, gotKey.Name)
-	}
-	if gotKey.PublicKey != kList[0].PublicKey {
-		t.Fatalf("Expected the name of the GOT plan to be %s, not %s", kList[0].PublicKey, gotKey.PublicKey)
-	}
+		if len(kList) == 0 {
+			t.Fatalf("Plan List should contain at least one plan")
+		}
 
-	// Update newly created SSH key
-	keyName = randString8()
-	skur := SSHKeyUpdateRequest{
-		Data: SSHKeyUpdateData{
-			ID:   k.ID,
-			Type: testSSHKeyType,
-			Attributes: SSHKeyUpdateAttributes{
-				Name: keyName,
+		// Get first listed SSHkey
+		gotKey, _, err := c.SSHKeys.Get(kList[0].ID, projectID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Check SSHKey data
+		if gotKey.ID != kList[0].ID {
+			t.Fatalf("Expected the id of the GOT plan to be %s, not %s", kList[0].ID, gotKey.ID)
+		}
+		if gotKey.Name != kList[0].Name {
+			t.Fatalf("Expected the Name of the GOT plan to be %s, not %s", kList[0].Name, gotKey.Name)
+		}
+		if gotKey.PublicKey != kList[0].PublicKey {
+			t.Fatalf("Expected the name of the GOT plan to be %s, not %s", kList[0].PublicKey, gotKey.PublicKey)
+		}
+	})
+
+	t.Run("Update SSH Key", func(t *testing.T) {
+		keyName := randString8()
+		skur := SSHKeyUpdateRequest{
+			Data: SSHKeyUpdateData{
+				ID:   keyID,
+				Type: testSSHKeyType,
+				Attributes: SSHKeyUpdateAttributes{
+					Name: keyName,
+				},
 			},
-		},
-	}
-	k, _, err = c.SSHKeys.Update(k.ID, projectID, &skur)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if k.Name != keyName {
-		t.Fatalf("Expected the name of the updated SSH key to be %s, not %s", keyName, k.Name)
-	}
+		}
+		k, _, err := c.SSHKeys.Update(keyID, projectID, &skur)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if k.Name != keyName {
+			t.Fatalf("Expected the name of the updated SSH key to be %s, not %s", keyName, k.Name)
+		}
 
-	kl, _, err := c.SSHKeys.List(projectID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+		kl, _, err := c.SSHKeys.List(projectID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if len(kl) != 1 {
-		t.Fatalf("SSH key List should contain exactly one key, was: %v", kl)
-	}
+		if len(kl) != 1 {
+			t.Fatalf("SSH key List should contain exactly one key, was: %v", kl)
+		}
+	})
 }

--- a/ssh_keys_test.go
+++ b/ssh_keys_test.go
@@ -40,9 +40,7 @@ func TestAccSSHKeyBasic(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if k.Name != keyName {
-			t.Fatalf("Expected new SSH key name to be %s, not %s", keyName, k.Name)
-		}
+		assertEqual(t, k.Name, keyName, "SSH Key Name")
 
 		keyID = k.ID
 	})
@@ -66,15 +64,9 @@ func TestAccSSHKeyBasic(t *testing.T) {
 		}
 
 		// Check SSHKey data
-		if gotKey.ID != kList[0].ID {
-			t.Fatalf("Expected the id of the GOT key to be %s, not %s", kList[0].ID, gotKey.ID)
-		}
-		if gotKey.Name != kList[0].Name {
-			t.Fatalf("Expected the Name of the GOT key to be %s, not %s", kList[0].Name, gotKey.Name)
-		}
-		if gotKey.PublicKey != kList[0].PublicKey {
-			t.Fatalf("Expected the name of the GOT key to be %s, not %s", kList[0].PublicKey, gotKey.PublicKey)
-		}
+		assertEqual(t, gotKey.ID, kList[0].ID, "SSH Key ID")
+		assertEqual(t, gotKey.Name, kList[0].Name, "SSH Key Name")
+		assertEqual(t, gotKey.PublicKey, kList[0].PublicKey, "SSH Key PublicKey")
 	})
 
 	t.Run("Update SSH Key", func(t *testing.T) {
@@ -92,17 +84,13 @@ func TestAccSSHKeyBasic(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if k.Name != keyName {
-			t.Fatalf("Expected the name of the updated SSH key to be %s, not %s", keyName, k.Name)
-		}
+		assertEqual(t, k.Name, keyName, "SSH Key Name")
 
 		kl, _, err := c.SSHKeys.List(projectID, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(kl) != 1 {
-			t.Fatalf("SSH key List should contain exactly one key, was: %v", kl)
-		}
+		assertEqual(t, len(kl), 1, "SSH Key List length")
 	})
 }

--- a/ssh_keys_test.go
+++ b/ssh_keys_test.go
@@ -56,7 +56,7 @@ func TestAccSSHKeyBasic(t *testing.T) {
 		}
 
 		if len(kList) == 0 {
-			t.Fatalf("Plan List should contain at least one plan")
+			t.Fatalf("SSH key List should contain at least one key")
 		}
 
 		// Get first listed SSHkey
@@ -67,13 +67,13 @@ func TestAccSSHKeyBasic(t *testing.T) {
 
 		// Check SSHKey data
 		if gotKey.ID != kList[0].ID {
-			t.Fatalf("Expected the id of the GOT plan to be %s, not %s", kList[0].ID, gotKey.ID)
+			t.Fatalf("Expected the id of the GOT key to be %s, not %s", kList[0].ID, gotKey.ID)
 		}
 		if gotKey.Name != kList[0].Name {
-			t.Fatalf("Expected the Name of the GOT plan to be %s, not %s", kList[0].Name, gotKey.Name)
+			t.Fatalf("Expected the Name of the GOT key to be %s, not %s", kList[0].Name, gotKey.Name)
 		}
 		if gotKey.PublicKey != kList[0].PublicKey {
-			t.Fatalf("Expected the name of the GOT plan to be %s, not %s", kList[0].PublicKey, gotKey.PublicKey)
+			t.Fatalf("Expected the name of the GOT key to be %s, not %s", kList[0].PublicKey, gotKey.PublicKey)
 		}
 	})
 

--- a/team_members_test.go
+++ b/team_members_test.go
@@ -14,39 +14,43 @@ func deleteMember(t *testing.T, c *Client, id string) {
 
 func TestAccMembersBasic(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
-
 	c, stopRecord := setup(t)
 	defer stopRecord()
 	defer projectTeardown(c)
 
-	// List Members
-	members, _, err := c.Members.List(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("List Members", func(t *testing.T) {
+		// List Members
+		members, _, err := c.Members.List(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if len(members) < 1 {
-		t.Fatal("Team must have at least a owner")
-	}
+		if len(members) < 1 {
+			t.Fatal("Team must have at least a owner")
+		}
+	})
 
-	//Create Member
-	request := MemberCreateRequest{
-		Data: MemberCreateData{
-			Type: "memberships",
-			Attributes: MemberCreateAttributes{
-				FirstName: "go-sdk",
-				LastName:  "test",
-				Email:     "go_sdk_test@latitude.sh",
-				Role:      Collaborator,
+	var memberID string
+	t.Run("Create Member", func(t *testing.T) {
+		request := MemberCreateRequest{
+			Data: MemberCreateData{
+				Type: "memberships",
+				Attributes: MemberCreateAttributes{
+					FirstName: "go-sdk",
+					LastName:  "test",
+					Email:     "go_sdk_test@latitude.sh",
+					Role:      Collaborator,
+				},
 			},
-		},
-	}
+		}
 
-	m, _, err := c.Members.Create(&request)
-	if err != nil {
-		t.Fatal(err)
-	}
+		m, _, err := c.Members.Create(&request)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	//Delete Member
-	deleteMember(t, c, m.ID)
+		memberID = m.ID
+	})
+
+	defer deleteMember(t, c, memberID)
 }

--- a/teams_test.go
+++ b/teams_test.go
@@ -36,13 +36,11 @@ func TestAccTeamBasic(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if team.Description != description {
-			t.Fatalf("Expected team description to be %s, not %s", description, team.Description)
-		}
+		assertEqual(t, team.Description, description, "Team Description")
 	})
 
 	t.Run("Get Team", func(t *testing.T) {
-        _, _, err := c.Teams.Get()
+		_, _, err := c.Teams.Get()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/teams_test.go
+++ b/teams_test.go
@@ -11,39 +11,40 @@ const (
 func TestAccTeamBasic(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	t.Parallel()
-
 	c, teardown := setup(t)
 	defer teardown()
 
-	// Create a new Team record
-	description := randString8()
-	name := randString8()
-	address := randString8()
+	t.Run("Create Team", func(t *testing.T) {
+		description := randString8()
+		name := randString8()
+		address := randString8()
 
-	tcr := TeamCreateRequest{
-		Data: TeamCreateData{
-			Type: testTeamType,
-			Attributes: TeamCreateAttributes{
-				Description: description,
-				Name:        name,
-				Currency:    "USD",
-				Address:     address,
+		tcr := TeamCreateRequest{
+			Data: TeamCreateData{
+				Type: testTeamType,
+				Attributes: TeamCreateAttributes{
+					Description: description,
+					Name:        name,
+					Currency:    "USD",
+					Address:     address,
+				},
 			},
-		},
-	}
+		}
 
-	k, _, err := c.Teams.Create(&tcr)
-	if err != nil {
-		t.Fatal(err)
-	}
+		team, _, err := c.Teams.Create(&tcr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if k.Description != description {
-		t.Fatalf("Expected team description to be %s, not %s", description, k.Description)
-	}
+		if team.Description != description {
+			t.Fatalf("Expected team description to be %s, not %s", description, team.Description)
+		}
+	})
 
-	// Get Team record
-	_, _, err = c.Teams.Get()
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("Get Team", func(t *testing.T) {
+        _, _, err := c.Teams.Get()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/user_data_test.go
+++ b/user_data_test.go
@@ -44,9 +44,7 @@ func TestAccUserDataBasic(t *testing.T) {
 
 		udID = ud.ID
 
-		if ud.Content != content {
-			t.Fatalf("Expected new User Data content to be %s, not %s", content, ud.Content)
-		}
+		assertEqual(t, ud.Content, content, "User Data content")
 	})
 
 	defer deleteUserData(t, c, udID, projectID)
@@ -67,9 +65,7 @@ func TestAccUserDataBasic(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ud.Description != description {
-			t.Fatalf("Expected the description of the updated User Data to be %s, not %s", description, ud.Description)
-		}
+		assertEqual(t, ud.Description, description, "User Data description")
 	})
 
 	t.Run("Get and List UserData", func(t *testing.T) {
@@ -77,17 +73,12 @@ func TestAccUserDataBasic(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		if len(udl) != 1 {
-			t.Fatalf("User Data List should contain exactly one key, was: %v", udl)
-		}
+		assertEqual(t, len(udl), 1, "User Data List length")
 
 		ud, _, err := c.UserData.Get(udID, projectID, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ud.ID != udl[0].ID {
-			t.Fatalf("Expected User Data ID to be %s, not %s", udl[0].ID, ud.ID)
-		}
+		assertEqual(t, ud.ID, udl[0].ID, "User Data ID")
 	})
 }

--- a/user_data_test.go
+++ b/user_data_test.go
@@ -21,65 +21,73 @@ func TestAccUserDataBasic(t *testing.T) {
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 
-	// Create a new UserData record
-	description := randString8()
-	content := testUserDataContent()
+	var udID string
 
-	udcr := UserDataCreateRequest{
-		Data: UserDataCreateData{
-			Type: testUserDataType,
-			Attributes: UserDataCreateAttributes{
-				Description: description,
-				Content:     content,
+	t.Run("Create UserData", func(t *testing.T) {
+		description := randString8()
+		content := testUserDataContent()
+
+		udcr := UserDataCreateRequest{
+			Data: UserDataCreateData{
+				Type: testUserDataType,
+				Attributes: UserDataCreateAttributes{
+					Description: description,
+					Content:     content,
+				},
 			},
-		},
-	}
+		}
 
-	k, _, err := c.UserData.Create(projectID, &udcr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer deleteUserData(t, c, k.ID, projectID)
+		ud, _, err := c.UserData.Create(projectID, &udcr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if k.Content != content {
-		t.Fatalf("Expected new User Data content to be %s, not %s", content, k.Content)
-	}
+		udID = ud.ID
 
-	// Update newly created User Data
-	description = randString8()
-	skur := UserDataUpdateRequest{
-		Data: UserDataUpdateData{
-			ID:   k.ID,
-			Type: testUserDataType,
-			Attributes: UserDataUpdateAttributes{
-				Description: description,
+		if ud.Content != content {
+			t.Fatalf("Expected new User Data content to be %s, not %s", content, ud.Content)
+		}
+	})
+
+	defer deleteUserData(t, c, udID, projectID)
+
+	t.Run("Update UserData", func(t *testing.T) {
+		// Update newly created User Data
+		description := randString8()
+		skur := UserDataUpdateRequest{
+			Data: UserDataUpdateData{
+				ID:   udID,
+				Type: testUserDataType,
+				Attributes: UserDataUpdateAttributes{
+					Description: description,
+				},
 			},
-		},
-	}
-	k, _, err = c.UserData.Update(k.ID, projectID, &skur)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if k.Description != description {
-		t.Fatalf("Expected the description of the updated User Data to be %s, not %s", description, k.Description)
-	}
+		}
+		ud, _, err := c.UserData.Update(udID, projectID, &skur)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ud.Description != description {
+			t.Fatalf("Expected the description of the updated User Data to be %s, not %s", description, ud.Description)
+		}
+	})
 
-	// List newly created User Data
-	kl, _, err := c.UserData.List(projectID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("Get and List UserData", func(t *testing.T) {
+		udl, _, err := c.UserData.List(projectID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if len(kl) != 1 {
-		t.Fatalf("User Data List should contain exactly one key, was: %v", kl)
-	}
+		if len(udl) != 1 {
+			t.Fatalf("User Data List should contain exactly one key, was: %v", udl)
+		}
 
-	// Get newly created User Data
-	k, _, err = c.UserData.Get(k.ID, projectID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if k.ID != kl[0].ID {
-		t.Fatalf("Expected User Data ID to be %s, not %s", kl[0].ID, k.ID)
-	}
+		ud, _, err := c.UserData.Get(udID, projectID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ud.ID != udl[0].ID {
+			t.Fatalf("Expected User Data ID to be %s, not %s", udl[0].ID, ud.ID)
+		}
+	})
 }

--- a/virtual_network_assignments_test.go
+++ b/virtual_network_assignments_test.go
@@ -103,33 +103,16 @@ func TestAccVlanAssignmentBasic(t *testing.T) {
 				continue
 			}
 
-			if vaTest.Type != va.Type {
-				t.Fatalf("Expected the type of the Vlan Assignment to be %s, not %s", vaTest.Type, va.Type)
-			}
-			if vaTest.Vid != va.Vid {
-				t.Fatalf("Expected the vid of the Vlan Assignment to be %d, not %d", vaTest.Vid, va.Vid)
-			}
-			if vaTest.Description != va.Description {
-				t.Fatalf("Expected the description of the Vlan Assignment to be %s, not %s", vaTest.Description, va.Description)
-			}
-			if vaTest.VirtualNetworkID != va.VirtualNetworkID {
-				t.Fatalf("Expected the virtual network id of the Vlan Assignment to be %s, not %s", vaTest.VirtualNetworkID, va.VirtualNetworkID)
-			}
-			if vaTest.Status != va.Status {
-				t.Fatalf("Expected the status of the Vlan Assignment to be %s, not %s", vaTest.Status, va.Status)
-			}
-			if vaTest.ServerID != va.ServerID {
-				t.Fatalf("Expected the server id of the Vlan Assignment to be %s, not %s", vaTest.ServerID, va.ServerID)
-			}
-			if vaTest.ServerHostname != va.ServerHostname {
-				t.Fatalf("Expected the server hostname of the Vlan Assignment to be %s, not %s", vaTest.ServerHostname, va.ServerHostname)
-			}
-			if vaTest.ServerLabel != va.ServerLabel {
-				t.Fatalf("Expected the server label of the Vlan Assignment to be %s, not %s", vaTest.ServerLabel, va.ServerLabel)
-			}
-			if vaTest.ServerStatus != va.ServerStatus {
-				t.Fatalf("Expected the server status of the Vlan Assignment to be %s, not %s", vaTest.ServerStatus, va.ServerStatus)
-			}
+			assertEqual(t, va.Type, vaTest.Type, "Vlan Assignment Type")
+			assertEqual(t, va.Vid, vaTest.Vid, "Vlan Assignment Vid")
+			assertEqual(t, va.Description, vaTest.Description, "Vlan Assignment Description")
+			assertEqual(t, va.VirtualNetworkID, vaTest.VirtualNetworkID, "Vlan Assignment VirtualNetworkID")
+			assertEqual(t, va.Status, vaTest.Status, "Vlan Assignment Status")
+			assertEqual(t, va.ServerID, vaTest.ServerID, "Vlan Assignment ServerID")
+			assertEqual(t, va.ServerHostname, vaTest.ServerHostname, "Vlan Assignment ServerHostname")
+			assertEqual(t, va.ServerLabel, vaTest.ServerLabel, "Vlan Assignment ServerLabel")
+			assertEqual(t, va.ServerStatus, vaTest.ServerStatus, "Vlan Assignment ServerStatus")
+
 			return
 		}
 		t.Fatalf("Vlan Assignment with id %s not found", vaTest.ID)

--- a/virtual_network_assignments_test.go
+++ b/virtual_network_assignments_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 )
 
-func TestAccVlanAssignmentBasic(t *testing.T) {
-	skipUnlessAcceptanceTestsAllowed(t)
-	c, projectID, teardown := setupWithProject(t)
-	defer teardown()
+func deleteVlanAssignment(t *testing.T, c *Client, id string) {
+	if _, err := c.VlanAssignments.Delete(id); err != nil {
+		t.Fatal(err)
+	}
+}
 
+func createServer(t *testing.T, c *Client, projectID string) *Server {
 	hn := randString8()
 	scr := ServerCreateRequest{
 		Data: ServerCreateData{
@@ -27,8 +29,10 @@ func TestAccVlanAssignmentBasic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer deleteServer(t, c, s.ID)
+	return s
+}
 
+func createVirtualNetwork(t *testing.T, c *Client, projectID string) *VirtualNetwork {
 	createRequest := VirtualNetworkCreateRequest{
 		Data: VirtualNetworkCreateData{
 			Type: "virtual_network",
@@ -43,72 +47,91 @@ func TestAccVlanAssignmentBasic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return vn
+}
+
+func TestAccVlanAssignmentBasic(t *testing.T) {
+	skipUnlessAcceptanceTestsAllowed(t)
+	c, projectID, teardown := setupWithProject(t)
+	defer teardown()
+
+	s := createServer(t, c, projectID)
+	defer deleteServer(t, c, s.ID)
+
+	vn := createVirtualNetwork(t, c, projectID)
 	defer c.VirtualNetworks.Delete(vn.ID)
 
-	assignRequest := VlanAssignRequest{
-		Data: VlanAssignData{
-			Type: "virtual_network_assignment",
-			Attributes: VlanAssignAttributes{
-				ServerID:         s.ID,
-				VirtualNetworkID: vn.ID,
+	var vlanID string
+
+	t.Run("Assing Virtual Network", func(t *testing.T) {
+		assignRequest := VlanAssignRequest{
+			Data: VlanAssignData{
+				Type: "virtual_network_assignment",
+				Attributes: VlanAssignAttributes{
+					ServerID:         s.ID,
+					VirtualNetworkID: vn.ID,
+				},
 			},
-		},
-	}
-
-	assign, _, err := c.VlanAssignments.Assign(&assignRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer c.VlanAssignments.Delete(assign.ID)
-
-	vaTest, _, err := c.VlanAssignments.Get(assign.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	val, _, err := c.VlanAssignments.List(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(val) == 0 {
-		t.Fatalf("Vlan Assignment List should contain at least one virtual network")
-	}
-
-	// Check Vlan Assignment data
-	for _, va := range val {
-		if va.ID != vaTest.ID {
-			continue
 		}
 
-		if vaTest.Type != va.Type {
-			t.Fatalf("Expected the type of the Vlan Assignment to be %s, not %s", vaTest.Type, va.Type)
+		assign, _, err := c.VlanAssignments.Assign(&assignRequest)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if vaTest.Vid != va.Vid {
-			t.Fatalf("Expected the vid of the Vlan Assignment to be %d, not %d", vaTest.Vid, va.Vid)
+		vlanID = assign.ID
+	})
+	defer deleteVlanAssignment(t, c, vlanID)
+
+	t.Run("Get and List Assignments", func(t *testing.T) {
+		vaTest, _, err := c.VlanAssignments.Get(vlanID)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if vaTest.Description != va.Description {
-			t.Fatalf("Expected the description of the Vlan Assignment to be %s, not %s", vaTest.Description, va.Description)
+
+		val, _, err := c.VlanAssignments.List(nil)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if vaTest.VirtualNetworkID != va.VirtualNetworkID {
-			t.Fatalf("Expected the virtual network id of the Vlan Assignment to be %s, not %s", vaTest.VirtualNetworkID, va.VirtualNetworkID)
+
+		if len(val) == 0 {
+			t.Fatalf("Vlan Assignment List should contain at least one virtual network")
 		}
-		if vaTest.Status != va.Status {
-			t.Fatalf("Expected the status of the Vlan Assignment to be %s, not %s", vaTest.Status, va.Status)
+
+		// Check Vlan Assignment data
+		for _, va := range val {
+			if va.ID != vaTest.ID {
+				continue
+			}
+
+			if vaTest.Type != va.Type {
+				t.Fatalf("Expected the type of the Vlan Assignment to be %s, not %s", vaTest.Type, va.Type)
+			}
+			if vaTest.Vid != va.Vid {
+				t.Fatalf("Expected the vid of the Vlan Assignment to be %d, not %d", vaTest.Vid, va.Vid)
+			}
+			if vaTest.Description != va.Description {
+				t.Fatalf("Expected the description of the Vlan Assignment to be %s, not %s", vaTest.Description, va.Description)
+			}
+			if vaTest.VirtualNetworkID != va.VirtualNetworkID {
+				t.Fatalf("Expected the virtual network id of the Vlan Assignment to be %s, not %s", vaTest.VirtualNetworkID, va.VirtualNetworkID)
+			}
+			if vaTest.Status != va.Status {
+				t.Fatalf("Expected the status of the Vlan Assignment to be %s, not %s", vaTest.Status, va.Status)
+			}
+			if vaTest.ServerID != va.ServerID {
+				t.Fatalf("Expected the server id of the Vlan Assignment to be %s, not %s", vaTest.ServerID, va.ServerID)
+			}
+			if vaTest.ServerHostname != va.ServerHostname {
+				t.Fatalf("Expected the server hostname of the Vlan Assignment to be %s, not %s", vaTest.ServerHostname, va.ServerHostname)
+			}
+			if vaTest.ServerLabel != va.ServerLabel {
+				t.Fatalf("Expected the server label of the Vlan Assignment to be %s, not %s", vaTest.ServerLabel, va.ServerLabel)
+			}
+			if vaTest.ServerStatus != va.ServerStatus {
+				t.Fatalf("Expected the server status of the Vlan Assignment to be %s, not %s", vaTest.ServerStatus, va.ServerStatus)
+			}
+			return
 		}
-		if vaTest.ServerID != va.ServerID {
-			t.Fatalf("Expected the server id of the Vlan Assignment to be %s, not %s", vaTest.ServerID, va.ServerID)
-		}
-		if vaTest.ServerHostname != va.ServerHostname {
-			t.Fatalf("Expected the server hostname of the Vlan Assignment to be %s, not %s", vaTest.ServerHostname, va.ServerHostname)
-		}
-		if vaTest.ServerLabel != va.ServerLabel {
-			t.Fatalf("Expected the server label of the Vlan Assignment to be %s, not %s", vaTest.ServerLabel, va.ServerLabel)
-		}
-		if vaTest.ServerStatus != va.ServerStatus {
-			t.Fatalf("Expected the server status of the Vlan Assignment to be %s, not %s", vaTest.ServerStatus, va.ServerStatus)
-		}
-		return
-	}
-	t.Fatalf("Vlan Assignment with id %s not found", vaTest.ID)
+		t.Fatalf("Vlan Assignment with id %s not found", vaTest.ID)
+	})
 }

--- a/virtual_networks_test.go
+++ b/virtual_networks_test.go
@@ -9,87 +9,95 @@ func TestAccVirtualNetworkBasic(t *testing.T) {
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 
-	// Create Virtual Network
-	createRequest := VirtualNetworkCreateRequest{
-		Data: VirtualNetworkCreateData{
-			Type: "virtual_network",
-			Attributes: VirtualNetworkCreateAttributes{
-				Description: "Testing Virtual Network via golang client",
-				Site:        testSite(),
-				Project:     projectID,
+	var vnId string
+
+	t.Run("Create Virtual Network", func(t *testing.T) {
+		createRequest := VirtualNetworkCreateRequest{
+			Data: VirtualNetworkCreateData{
+				Type: "virtual_network",
+				Attributes: VirtualNetworkCreateAttributes{
+					Description: "Testing Virtual Network via golang client",
+					Site:        testSite(),
+					Project:     projectID,
+				},
 			},
-		},
-	}
+		}
 
-	vnNew, _, err := c.VirtualNetworks.Create(&createRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer c.VirtualNetworks.Delete(vnNew.ID)
+		vnNew, _, err := c.VirtualNetworks.Create(&createRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vnId = vnNew.ID
+	})
+	defer c.VirtualNetworks.Delete(vnId)
 
-	updateRequest := VirtualNetworkUpdateRequest{
-		Data: VirtualNetworkUpdateData{
-			ID:   vnNew.ID,
-			Type: "virtual_networks",
-			Attributes: VirtualNetworkUpdateAttributes{
-				Description: "Updating Virtual Network via golang client",
+	t.Run("Update Virtual Network", func(t *testing.T) {
+		updateRequest := VirtualNetworkUpdateRequest{
+			Data: VirtualNetworkUpdateData{
+				ID:   vnId,
+				Type: "virtual_networks",
+				Attributes: VirtualNetworkUpdateAttributes{
+					Description: "Updating Virtual Network via golang client",
+				},
 			},
-		},
-	}
-
-	_, _, err = c.VirtualNetworks.Update(vnNew.ID, &updateRequest)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	vnTest, _, err := c.VirtualNetworks.Get(vnNew.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	vnl, _, err := c.VirtualNetworks.List(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(vnl) == 0 {
-		t.Fatalf("Virtual Network List should contain at least one virtual network")
-	}
-
-	// Check Virtual Network data
-	for _, vn := range vnl {
-		if vn.ID != vnTest.ID {
-			continue
 		}
 
-		if vnTest.Type != vn.Type {
-			t.Fatalf("Expected the type of the Virtual Network to be %s, not %s", vnTest.Type, vn.Type)
+		_, _, err := c.VirtualNetworks.Update(vnId, &updateRequest)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if vnTest.Vid != vn.Vid {
-			t.Fatalf("Expected the vid of the Virtual Network to be %d, not %d", vnTest.Vid, vn.Vid)
+	})
+
+	t.Run("Get and List Virtual Networks", func(t *testing.T) {
+		vnTest, _, err := c.VirtualNetworks.Get(vnId, nil)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if vnTest.Description != vn.Description {
-			t.Fatalf("Expected the description of the Virtual Network to be %s, not %s", vnTest.Description, vn.Description)
+
+		vnl, _, err := c.VirtualNetworks.List(nil)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if vnTest.City != vn.City {
-			t.Fatalf("Expected the region city of the Virtual Network to be %s, not %s", vnTest.City, vn.City)
+
+		if len(vnl) == 0 {
+			t.Fatalf("Virtual Network List should contain at least one virtual network")
 		}
-		if vnTest.Country != vn.Country {
-			t.Fatalf("Expected the region country of the Virtual Network to be %s, not %s", vnTest.Country, vn.Country)
+
+		// Check Virtual Network data
+		for _, vn := range vnl {
+			if vn.ID != vnTest.ID {
+				continue
+			}
+
+			if vnTest.Type != vn.Type {
+				t.Fatalf("Expected the type of the Virtual Network to be %s, not %s", vnTest.Type, vn.Type)
+			}
+			if vnTest.Vid != vn.Vid {
+				t.Fatalf("Expected the vid of the Virtual Network to be %d, not %d", vnTest.Vid, vn.Vid)
+			}
+			if vnTest.Description != vn.Description {
+				t.Fatalf("Expected the description of the Virtual Network to be %s, not %s", vnTest.Description, vn.Description)
+			}
+			if vnTest.City != vn.City {
+				t.Fatalf("Expected the region city of the Virtual Network to be %s, not %s", vnTest.City, vn.City)
+			}
+			if vnTest.Country != vn.Country {
+				t.Fatalf("Expected the region country of the Virtual Network to be %s, not %s", vnTest.Country, vn.Country)
+			}
+			if vnTest.SiteId != vn.SiteId {
+				t.Fatalf("Expected the site id of the Virtual Network to be %s, not %s", vnTest.SiteId, vn.SiteId)
+			}
+			if vnTest.SiteName != vn.SiteName {
+				t.Fatalf("Expected the site name of the Virtual Network to be %s, not %s", vnTest.SiteName, vn.SiteName)
+			}
+			if vnTest.SiteSlug != vn.SiteSlug {
+				t.Fatalf("Expected the site slug of the Virtual Network to be %s, not %s", vnTest.SiteSlug, vn.SiteSlug)
+			}
+			if vnTest.Facility != vn.Facility {
+				t.Fatalf("Expected the facility of the Virtual Network to be %s, not %s", vnTest.Facility, vn.Facility)
+			}
+			return
 		}
-		if vnTest.SiteId != vn.SiteId {
-			t.Fatalf("Expected the site id of the Virtual Network to be %s, not %s", vnTest.SiteId, vn.SiteId)
-		}
-		if vnTest.SiteName != vn.SiteName {
-			t.Fatalf("Expected the site name of the Virtual Network to be %s, not %s", vnTest.SiteName, vn.SiteName)
-		}
-		if vnTest.SiteSlug != vn.SiteSlug {
-			t.Fatalf("Expected the site slug of the Virtual Network to be %s, not %s", vnTest.SiteSlug, vn.SiteSlug)
-		}
-		if vnTest.Facility != vn.Facility {
-			t.Fatalf("Expected the facility of the Virtual Network to be %s, not %s", vnTest.Facility, vn.Facility)
-		}
-		return
-	}
-	t.Fatalf("Virtual Network with id %s not found", vnTest.ID)
+		t.Fatalf("Virtual Network with id %s not found", vnTest.ID)
+	})
 }

--- a/virtual_networks_test.go
+++ b/virtual_networks_test.go
@@ -4,12 +4,18 @@ import (
 	"testing"
 )
 
+func deleteVirtualNetwork(t *testing.T, c *Client, id string) {
+	if _, err := c.VirtualNetworks.Delete(id); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAccVirtualNetworkBasic(t *testing.T) {
 	skipUnlessAcceptanceTestsAllowed(t)
 	c, projectID, teardown := setupWithProject(t)
 	defer teardown()
 
-	var vnId string
+	var vnID string
 
 	t.Run("Create Virtual Network", func(t *testing.T) {
 		createRequest := VirtualNetworkCreateRequest{
@@ -27,14 +33,14 @@ func TestAccVirtualNetworkBasic(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		vnId = vnNew.ID
+		vnID = vnNew.ID
 	})
-	defer c.VirtualNetworks.Delete(vnId)
+	defer deleteVirtualNetwork(t, c, vnID)
 
 	t.Run("Update Virtual Network", func(t *testing.T) {
 		updateRequest := VirtualNetworkUpdateRequest{
 			Data: VirtualNetworkUpdateData{
-				ID:   vnId,
+				ID:   vnID,
 				Type: "virtual_networks",
 				Attributes: VirtualNetworkUpdateAttributes{
 					Description: "Updating Virtual Network via golang client",
@@ -42,14 +48,14 @@ func TestAccVirtualNetworkBasic(t *testing.T) {
 			},
 		}
 
-		_, _, err := c.VirtualNetworks.Update(vnId, &updateRequest)
+		_, _, err := c.VirtualNetworks.Update(vnID, &updateRequest)
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("Get and List Virtual Networks", func(t *testing.T) {
-		vnTest, _, err := c.VirtualNetworks.Get(vnId, nil)
+		vnTest, _, err := c.VirtualNetworks.Get(vnID, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/virtual_networks_test.go
+++ b/virtual_networks_test.go
@@ -75,33 +75,16 @@ func TestAccVirtualNetworkBasic(t *testing.T) {
 				continue
 			}
 
-			if vnTest.Type != vn.Type {
-				t.Fatalf("Expected the type of the Virtual Network to be %s, not %s", vnTest.Type, vn.Type)
-			}
-			if vnTest.Vid != vn.Vid {
-				t.Fatalf("Expected the vid of the Virtual Network to be %d, not %d", vnTest.Vid, vn.Vid)
-			}
-			if vnTest.Description != vn.Description {
-				t.Fatalf("Expected the description of the Virtual Network to be %s, not %s", vnTest.Description, vn.Description)
-			}
-			if vnTest.City != vn.City {
-				t.Fatalf("Expected the region city of the Virtual Network to be %s, not %s", vnTest.City, vn.City)
-			}
-			if vnTest.Country != vn.Country {
-				t.Fatalf("Expected the region country of the Virtual Network to be %s, not %s", vnTest.Country, vn.Country)
-			}
-			if vnTest.SiteId != vn.SiteId {
-				t.Fatalf("Expected the site id of the Virtual Network to be %s, not %s", vnTest.SiteId, vn.SiteId)
-			}
-			if vnTest.SiteName != vn.SiteName {
-				t.Fatalf("Expected the site name of the Virtual Network to be %s, not %s", vnTest.SiteName, vn.SiteName)
-			}
-			if vnTest.SiteSlug != vn.SiteSlug {
-				t.Fatalf("Expected the site slug of the Virtual Network to be %s, not %s", vnTest.SiteSlug, vn.SiteSlug)
-			}
-			if vnTest.Facility != vn.Facility {
-				t.Fatalf("Expected the facility of the Virtual Network to be %s, not %s", vnTest.Facility, vn.Facility)
-			}
+            assertEqual(t, vn.Type, vnTest.Type, "Virtual Network Type")
+            assertEqual(t, vn.Vid, vnTest.Vid, "Virtual Network Vid")
+            assertEqual(t, vn.Description, vnTest.Description, "Virtual Network Description")
+            assertEqual(t, vn.City, vnTest.City, "Virtual Network City")
+            assertEqual(t, vn.Country, vnTest.Country, "Virtual Network Country")
+            assertEqual(t, vn.SiteId, vnTest.SiteId, "Virtual Network SiteId")
+            assertEqual(t, vn.SiteName, vnTest.SiteName, "Virtual Network SiteName")
+            assertEqual(t, vn.SiteSlug, vnTest.SiteSlug, "Virtual Network SiteSlug")
+            assertEqual(t, vn.Facility, vnTest.Facility, "Virtual Network Facility")
+
 			return
 		}
 		t.Fatalf("Virtual Network with id %s not found", vnTest.ID)


### PR DESCRIPTION
#### What does this PR do?
This PR aims to verify all of our existing endpoints to prepare for our terraform provider `v1.0.0` launch.

Most of the refactoring done by this PR is organizing the tests in subtests. This way it's easier to verify where a test is failing. Also, there were some adjustments to some delete test functions.

#### Description of Task to be completed
Verify and refactor tests in order to guarantee all the SDK functionality.

*Verified endpoints:*
- [x] Servers
- [x] Virtual Networks
- [x] Virtual Networks Assignments
- [x] Operating Systems
- [x] Plans
- [x] Projects
- [x] Regions
- [x] SSH Keys
- [x] Teams
- [x] Team Members
- [x] User Data 

#### How to test?
To run the tests, use the following command:
```
LATITUDE_AUTH_TOKEN=<API-TOKEN> LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=<RECORD-MODE> go test -run "^<Test-NAME>$"
```
`<API-TOKEN>` : Your API token
`<RECORD-MODE>` : can be `record` (will record the interactions with the api and save in a fixtures folder) or `play` (will play the recorded interactions instead of doing the actual requests to the api)
`<Test-NAME>` : the Name of the test function that you want to run (you can verify them at the `*_tests.go` files) 

⚠️ Attention
- When running all the tests at the same time, some of them might fail because of a bug (golang tries to create the same project more than once) I'll investigate it and open another PR solving this issue. At the time being the only way to have a clean test is to run each one on it's own.
- As the tests run against production, `TestAccServerBasic` can fail due to stock levels.
- Unfortunately, running `TestAccTeamBasic` will create another team in production (and we don't have an endpoint to delete teams from what i've seen). I'm studying the possibility of mocking some of the API calls so we don't span the API.
