### PR TITLE
feat: add get method to tags

### DIFF
--- a/latitude.go
+++ b/latitude.go
@@ -24,7 +24,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "0.3.2"
+var currentVersion = "0.3.3"
 
 // meta contains pagination information
 type meta struct {

--- a/tags.go
+++ b/tags.go
@@ -1,11 +1,16 @@
 package latitude
 
-import "path"
+import (
+	"errors"
+	"net/http"
+	"path"
+)
 
 const tagBasePath = "/tags"
 
 type TagsService interface {
 	List(*ListOptions) ([]Tag, *Response, error)
+	Get(string) (*Tag, *Response, error)
 	Create(*TagCreateRequest) (*Tag, *Response, error)
 	Update(string, *TagUpdateRequest) (*Tag, *Response, error)
 	Delete(string) (*Response, error)
@@ -135,6 +140,26 @@ func (t *TagServiceOp) List(opts *ListOptions) ([]Tag, *Response, error) {
 
 		return tags, resp, err
 	}
+}
+
+func (t *TagServiceOp) Get(tagID string) (*Tag, *Response, error) {
+	tags, resp, err := t.List(nil)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	for _, tag := range tags {
+		if tag.ID == tagID {
+			return &tag, resp, nil
+		}
+	}
+
+	resp.Status = "404 Not Found"
+	resp.StatusCode = http.StatusNotFound
+
+	notFoundErr := errors.New("ERROR\nStatus: 404\nSpecified Record Not Found")
+
+	return nil, resp, notFoundErr
 }
 
 func (t *TagServiceOp) Create(createRequest *TagCreateRequest) (*Tag, *Response, error) {

--- a/tags_test.go
+++ b/tags_test.go
@@ -21,7 +21,7 @@ func TestAccTagBasic(t *testing.T) {
 
 	var tagID string
 
-	t.Run("Tags Create test", func(t *testing.T) {
+	t.Run("Create Tags", func(t *testing.T) {
 		rs := randString8()
 		tcr := TagCreateRequest{
 			Data: TagCreateData{
@@ -46,7 +46,7 @@ func TestAccTagBasic(t *testing.T) {
 	// delete the tag at the end of the tests
 	defer deleteTag(t, c, tagID)
 
-	t.Run("Tags Update test", func(t *testing.T) {
+	t.Run("Update Tags", func(t *testing.T) {
 		rs := randString8()
 		tur := TagUpdateRequest{
 			Data: TagUpdateData{
@@ -68,7 +68,12 @@ func TestAccTagBasic(t *testing.T) {
 		assertEqual(t, tag.Name, rs, "Project Name")
 	})
 
-	t.Run("Tags List test", func(t *testing.T) {
+	t.Run("Get and List Tags", func(t *testing.T) {
+		tagTest, _, err := c.Tags.Get(tagID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		dl, _, err := c.Tags.List(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -76,5 +81,19 @@ func TestAccTagBasic(t *testing.T) {
 		if len(dl) < 1 {
 			t.Fatal("There should be at least one tag created")
 		}
+
+		for _, tag := range dl {
+			if tag.ID != tagTest.ID {
+				continue
+			}
+
+			assertEqual(t, tag.Name, tagTest.Name, "Tag Name")
+			assertEqual(t, tag.Slug, tagTest.Slug, "Tag Slug")
+			assertEqual(t, tag.Description, tagTest.Description, "Tag Description")
+			assertEqual(t, tag.Color, tagTest.Color, "Tag Color")
+			assertEqual(t, tag.TeamID, tagTest.TeamID, "Tag TeamID")
+			return
+		}
+		t.Fatalf("Tag with id %s not found", tagTest.ID)
 	})
 }


### PR DESCRIPTION
#### What does this PR do?
A Get method is needed for the terraform provider in order to keep track of the state of the resource.

#### Description of Task to be completed?
- Implement Get Tags

#### How should this be manually tested?
By using golang test suit you can run all our tests
```
LATITUDE_AUTH_TOKEN=<API-TOKEN> LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=<RECORD-MODE> go test -run "Tag" -v
``` 
The `<RECORD-MODE>` variable can be `record` or `play`
`<API-TOKEN>` Your API token.


For manual testing use `go get` to download this branch:

```
go get github.com/latitudesh/latitudesh-go@add-get-method-to-tags
```
