### PR TITLE
fix: missing fields from create/update response

### DIFF
--- a/virtual_network_assignments.go
+++ b/virtual_network_assignments.go
@@ -63,6 +63,25 @@ type VlanAssignmentGetResponse struct {
 	Meta meta               `json:"meta"`
 }
 
+type VlanAssignmentCreateResponse struct {
+	Data VlanAssignmentCreateData `json:"data"`
+	Meta meta                     `json:"meta"`
+}
+
+type VlanAssignmentCreateData struct {
+	ID         string                         `json:"id"`
+	Type       string                         `json:"type"`
+	Attributes VlanAssignmentCreateAttributes `json:"attributes"`
+}
+
+type VlanAssignmentCreateAttributes struct {
+	VirtualNetworkID string `json:"virtual_network_id"`
+	Vid              int    `json:"vid"`
+	Description      string `json:"description"`
+	Status           string `json:"status"`
+	ServerId         string `json:"server_id"`
+}
+
 type VlanAssignRequest struct {
 	Data VlanAssignData `json:"data"`
 }
@@ -89,6 +108,18 @@ func NewFlatVlanAssignment(vnd VlanAssignmentData) VlanAssignment {
 		vnd.Attributes.Server.Hostname,
 		vnd.Attributes.Server.Status,
 		vnd.Attributes.Server.Label,
+	}
+}
+
+func NewCreateFlatVlanAssignment(vnd VlanAssignmentCreateData) VlanAssignment {
+	return VlanAssignment{
+		ID:               vnd.ID,
+		Type:             vnd.Type,
+		VirtualNetworkID: vnd.Attributes.VirtualNetworkID,
+		Vid:              vnd.Attributes.Vid,
+		Description:      vnd.Attributes.Description,
+		Status:           vnd.Attributes.Status,
+		ServerID:         vnd.Attributes.ServerId,
 	}
 }
 
@@ -141,14 +172,14 @@ func (s *VlanAssignmentServiceOp) Get(vlanAssignmentID string) (*VlanAssignment,
 }
 
 func (s *VlanAssignmentServiceOp) Assign(assignRequest *VlanAssignRequest) (*VlanAssignment, *Response, error) {
-	vLan := new(VlanAssignmentGetResponse)
+	vLan := new(VlanAssignmentCreateResponse)
 
 	resp, err := s.client.DoRequest("POST", vlanAssignmentBasePath, assignRequest, vLan)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	flatVlanAssignment := NewFlatVlanAssignment(vLan.Data)
+	flatVlanAssignment := NewCreateFlatVlanAssignment(vLan.Data)
 	return &flatVlanAssignment, resp, err
 }
 

--- a/virtual_networks.go
+++ b/virtual_networks.go
@@ -68,6 +68,27 @@ type VirtualNetworkGetResponse struct {
 	Meta meta               `json:"meta"`
 }
 
+type VirtualNetworkPostData struct {
+	ID         string                       `json:"id"`
+	Type       string                       `json:"type"`
+	Attributes VirtualNetworkPostAttributes `json:"attributes"`
+}
+
+type VirtualNetworkPostAttributes struct {
+	Vid         int        `json:"vid"`
+	Description string     `json:"description"`
+	Site        string     `json:"site"`
+	Tags        []EmbedTag `json:"tags"`
+	Name        string     `json:"name"`
+}
+
+type VirtualNetworkCreateResponse struct {
+	Data VirtualNetworkPostData `json:"data"`
+	Meta meta                   `json:"meta"`
+}
+
+type VirtualNetworkUpdateResponse VirtualNetworkCreateResponse
+
 type VirtualNetworkCreateRequest struct {
 	Data VirtualNetworkCreateData `json:"data"`
 }
@@ -112,6 +133,17 @@ func NewFlatVirtualNetwork(vnd VirtualNetworkData) VirtualNetwork {
 		vnd.Attributes.Region.Site.Facility,
 		vnd.Attributes.AssignmentsCount,
 		vnd.Attributes.Tags,
+	}
+}
+
+func NewFlatCreatedVirtualNetwork(vnd VirtualNetworkPostData) VirtualNetwork {
+	return VirtualNetwork{
+		ID:          vnd.ID,
+		Type:        vnd.Type,
+		Vid:         vnd.Attributes.Vid,
+		Description: vnd.Attributes.Description,
+		SiteSlug:    vnd.Attributes.Site,
+		Tags:        vnd.Attributes.Tags,
 	}
 }
 
@@ -160,28 +192,28 @@ func (s *VirtualNetworkServiceOp) Get(virtualNetworkID string, opts *GetOptions)
 
 // Create creates a new virtual network
 func (s *VirtualNetworkServiceOp) Create(createRequest *VirtualNetworkCreateRequest) (*VirtualNetwork, *Response, error) {
-	vLan := new(VirtualNetworkGetResponse)
+	virtualNetwork := new(VirtualNetworkCreateResponse)
 
-	resp, err := s.client.DoRequest("POST", virtualNetworkBasePath, createRequest, vLan)
+	resp, err := s.client.DoRequest("POST", virtualNetworkBasePath, createRequest, virtualNetwork)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	flatVirtualNetwork := NewFlatVirtualNetwork(vLan.Data)
+	flatVirtualNetwork := NewFlatCreatedVirtualNetwork(virtualNetwork.Data)
 	return &flatVirtualNetwork, resp, err
 }
 
 // Update updates a virtual network
 func (s *VirtualNetworkServiceOp) Update(virtualNetworkID string, updateRequest *VirtualNetworkUpdateRequest) (*VirtualNetwork, *Response, error) {
 	apiPath := path.Join(virtualNetworkBasePath, virtualNetworkID)
-	virtualNetwork := new(VirtualNetworkGetResponse)
+	virtualNetwork := new(VirtualNetworkUpdateResponse)
 
 	resp, err := s.client.DoRequest("PATCH", apiPath, updateRequest, virtualNetwork)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	flatVirtualNetwork := NewFlatVirtualNetwork(virtualNetwork.Data)
+	flatVirtualNetwork := NewFlatCreatedVirtualNetwork(virtualNetwork.Data)
 	return &flatVirtualNetwork, resp, err
 }
 


### PR DESCRIPTION
#### What does this PR do?
Our virtual network and virtual network assignment creation responses are missing some attributes that are returned from the API (their create response is different from the get response). This PR aims to fix that.

This shouldn't affect the SDK usage.

#### Description of Task to be completed?
- Create the structs with the attributes that the API returns.

#### How should this be manually tested?
By using golang test suit you can run all our tests
```
LATITUDE_AUTH_TOKEN=<API-TOKEN> LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=<RECORD-MODE> go test -run "<TestName>" -v
``` 
The `<RECORD-MODE>` variable can be `record` or `play`
`<API-TOKEN>` Your API token.
`<TestName>` String that will be used to match the test name: VirtualNetwork and Vlan.
