### PR TITLE
chore: update go version and ghactions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,20 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.22.4'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.1.0
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/latitudesh/latitudesh-go
 
-go 1.17
+go 1.22.4
 
 require gopkg.in/dnaeon/go-vcr.v3 v3.1.2
 

--- a/latitude.go
+++ b/latitude.go
@@ -24,7 +24,7 @@ const (
 	userAgentForProvider = "Latitude-Terraform-Provider"
 )
 
-var currentVersion = "0.3.2"
+var currentVersion = "0.4.2"
 
 // meta contains pagination information
 type meta struct {


### PR DESCRIPTION
## #### What does this PR do?
Update Golang version to 1.22.4, ghAction steps to their latest version and goreleaser to v2. Also update the currentVersion variable.
