### PR TITLE
feat: add GHAction to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: "Run go test"
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.22.4'
+      - name: Install dependencies
+        run: go get .
+      - name: Build
+        run: go build -v ./...
+      - name: Test with the Go CLI
+        run: LATITUDE_AUTH_TOKEN="recorded-key" LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=play go test -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '^1.22.4'
-      - name: Install dependencies
+      - 
+        name: Install dependencies
         run: go get .
-      - name: Build
+      - 
+        name: Build
         run: go build -v ./...
-      - name: Test with the Go CLI
+      - 
+        name: Test with the Go CLI
         run: LATITUDE_AUTH_TOKEN="recorded-key" LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=play go test -v

--- a/latitude_test.go
+++ b/latitude_test.go
@@ -182,9 +182,9 @@ func setup(t *testing.T) (*Client, func()) {
 		apiURL = baseURL
 	}
 	r, stopRecord := testRecorder(t, name, mode)
-	httpClient := http.DefaultClient
+	httpClient := *http.DefaultClient
 	httpClient.Transport = r
-	c, err := NewClientWithBaseURL(apiToken, httpClient, apiURL)
+	c, err := NewClientWithBaseURL(apiToken, &httpClient, apiURL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### What does this PR do?
This PR adds a GH Action to run go test. It also fixes a race condition that was causing tests to fail when running the entire suite.

#### Description of Task to be completed?
- Add the action file.
- Investigate and resolve race conditions in the tests.

#### How should this be manually tested?
To verify that all tests can run concurrently, you should run the following command:
```
LATITUDE_AUTH_TOKEN="recorded-key" LATITUDE_TEST_ACTUAL_API=true LATITUDE_TEST_RECORDER=play go test -race -v
```
This command should be run exactly as written. The `recorded-key` is a placeholder since the test runner requires an authentication token to be defined. (An actual token was already used to record the tests, so it does not need to be set again.)

the `-race` flag will detect and report any race conditions.
