### PR TITLE
deprecate: go sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,4 @@
-# latitudesh-go
-[![GoDoc](https://godoc.org/github.com/latitudesh/latitudesh-go?status.svg)](https://godoc.org/github.com/latitudesh/latitudesh-go)
+### Deprecated
 
-latitudesh-go is a Go client library for accessing the Latitude.sh API.
-
-You can view the API docs here: https://docs.latitude.sh/reference
-
-
-## Install
-```sh
-go get github.com/latitudesh/latitudesh-go@vX.Y.Z
-```
-
-where X.Y.Z is the [version](https://github.com/latitudesh/latitudesh-go/releases) you need.
-
-## Usage
-
-```go
-package main
-
-import (
-    latitude "github.com/latitudesh/latitudesh-go"
-)
-
-func main() {
-    client := latitude.NewClientWithAuth("Latitude.sh", apiToken, nil)
-}
-```
+This repository is deprecated. Please use the [latitudesh-go-sdk](https://github.com/latitudesh/latitudesh-go-sdk) repository instead.
 


### PR DESCRIPTION
Deprecate this SDK (before archiving) and point to the new one.